### PR TITLE
Elide bounds checks in uo_hash64_with_seeds

### DIFF
--- a/src/farmhashcc_shared.rs
+++ b/src/farmhashcc_shared.rs
@@ -142,10 +142,10 @@ pub fn weak_hash_len_32_with_seeds(w: u64, x: u64, y:u64, z:u64, mut a:u64, mut 
 // Return a 16-byte hash for s[0] ... s[31], a, and b.  Quick and dirty.
 // Note: original C++ returned a pair<uint64_t, uint64_t>
 pub fn weak_hash_len_32_with_seeds_bytes(s: &[u8], a:u64, b:u64) -> Uint128 {
-    return weak_hash_len_32_with_seeds(fetch64(s),
-        fetch64(&s[8..]),
-        fetch64(&s[16..]),
-        fetch64(&s[24..]),
+    return weak_hash_len_32_with_seeds(fetch64(&s[0..8]),
+        fetch64(&s[8..16]),
+        fetch64(&s[16..24]),
+        fetch64(&s[24..32]),
         a,
         b);
 }

--- a/src/farmhashna.rs
+++ b/src/farmhashna.rs
@@ -27,8 +27,6 @@ pub fn na_hash64(mut s: &[u8]) -> u64 {
 
     x = x.wrapping_mul(K2).wrapping_add(fetch64(s));
 
-    // Set end so that after the loop we have 1 to 64 bytes left to process.
-    let end = &s[((len - 1) / 64) * 64..];
     let last64 = &s[len - 64..];
     while {
         x = rotate64(x.wrapping_add(y).wrapping_add(v.first).wrapping_add(fetch64(&s[8..])), 37).wrapping_mul(K1);
@@ -41,7 +39,7 @@ pub fn na_hash64(mut s: &[u8]) -> u64 {
 
         mem::swap(&mut z, &mut x);
         s = &s[64..];
-        s.len() != end.len()
+        s.len() >= 64
     } {}
 
     let mul = K1 + ((z & 0xff) << 1);

--- a/src/farmhashna_shared.rs
+++ b/src/farmhashna_shared.rs
@@ -34,8 +34,8 @@ pub fn hash_len_0_to_16(s: &[u8]) -> u64 {
     }
     if len > 0 {
         let a = s[0];
-        let b = s[len>>1];
-        let c = s[len-1];
+        let b = if len >= 2 { s[1] } else { a }; // s[len / 2]
+        let c = s[len - 1];
         let y = a as u32 + ((b as u32) << 8);
         let z = len as u64 + ((c as u64) << 2);
         return shift_mix((y as u64).wrapping_mul(K2) ^ z.wrapping_mul(K0)).wrapping_mul(K2);

--- a/src/farmhashuo.rs
+++ b/src/farmhashuo.rs
@@ -28,19 +28,19 @@ pub fn uo_hash64_with_seeds(mut s: &[u8], seed0: u64, seed1: u64) -> u64 {
     x = x.wrapping_mul(K2);
     let mul = K2.wrapping_add(u & 0x82);
 
-    // Set end so that after the loop we have 1 to 64 bytes left to process.
-    let end = &s[((len - 1) / 64) * 64..];
+    // Process the input in blocks of 64 bytes
     let last64 = &s[len - 64..];
 
-    while s.len() != end.len() {
-        let a0 = fetch64(s);
-        let a1 = fetch64(&s[8..]);
-        let a2 = fetch64(&s[16..]);
-        let a3 = fetch64(&s[24..]);
-        let a4 = fetch64(&s[32..]);
-        let a5 = fetch64(&s[40..]);
-        let a6 = fetch64(&s[48..]);
-        let a7 = fetch64(&s[56..]);
+    while s.len() >= 64 {
+        // The `s.len() >= 64` should allow the boundary checks to be elided.
+        let a0 = fetch64(&s[0..8]);
+        let a1 = fetch64(&s[8..16]);
+        let a2 = fetch64(&s[16..24]);
+        let a3 = fetch64(&s[24..32]);
+        let a4 = fetch64(&s[32..40]);
+        let a5 = fetch64(&s[40..48]);
+        let a6 = fetch64(&s[48..56]);
+        let a7 = fetch64(&s[56..64]);
         x = x.wrapping_add(a0).wrapping_add(a1);
         y = y.wrapping_add(a2);
         z = z.wrapping_add(a3);


### PR DESCRIPTION
Elide bounds checks in uo_hash64_with_seeds

Write the loop just slightly differently.

With `while s.len() >= 64 {`, the optimizer can elide the bounds
checks for the slicing in the loop, since they follow from `s.len() >= 64`.

Use fully explicit slice ranges, so tha the assertion for length in
fetch64 is optimized out as well.

This improves the benchmark bench_pseurand_big_farm_direct by 15%.
