### PR TITLE
Expose stable, “fingerprinting” hash functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod farmhashna_shared;
 mod farmhashcc_shared;
 mod farmhashmk_shared;
 
+use farmhashna::na_hash64;
 use farmhashmk::mk_hash32;
 use farmhashmk::mk_hash32_with_seed;
 use farmhashxo::xo_hash64;
@@ -54,6 +55,31 @@ pub fn hash64_with_seeds(s: &[u8], seed0: u64, seed1: u64) -> u64 {
     xo_hash64_with_seeds(s, seed0, seed1)
 }
 
+/// Create a stable farmhash based u32 for an array of bytes.
+///
+/// # Examples
+///
+/// ```
+/// let value: &str = "hello world";
+/// let res32 = farmhash::fingerprint32(&value.as_bytes());
+/// //res32 ==> 430397466
+/// ```
+pub fn fingerprint32(s: &[u8]) -> u32 {
+    mk_hash32(s)
+}
+
+/// Create a stable farmhash based u64 for an array of bytes.
+///
+/// # Examples
+///
+/// ```
+/// let value: &str = "hello world";
+/// let res64 = farmhash::fingerprint64(&value.as_bytes());
+/// //res64 ==> 6381520714923946011
+/// ```
+pub fn fingerprint64(s: &[u8]) -> u64 {
+    na_hash64(s)
+}
 
 pub struct FarmHasher {
     bytes: Vec<u8>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use farmhashxo::xo_hash64_with_seed;
 use farmhashxo::xo_hash64_with_seeds;
 use std::hash::Hasher;
 
-/// Create a new farmhash based u32 for a gives array of bytes.
+/// Create a new farmhash based u32 for an array of bytes.
 ///
 /// # Examples
 ///
@@ -26,12 +26,12 @@ use std::hash::Hasher;
 pub fn hash32(s: &[u8]) -> u32 {
     mk_hash32(s)
 }
-/// Create a new farmhash based u32 for a gives array of bytes with a given seed.
+/// Create a new farmhash based u32 for an array of bytes with a given seed.
 pub fn hash32_with_seed(s: &[u8], seed: u32) -> u32 {
     mk_hash32_with_seed(s, seed)
 }
 
-/// Create a new farmhash based u64 for a gives array of bytes.
+/// Create a new farmhash based u64 for an array of bytes.
 ///
 /// # Examples
 ///
@@ -44,12 +44,12 @@ pub fn hash64(s: &[u8]) -> u64 {
     xo_hash64(s)
 }
 
-/// Create a new farmhash based u64 for a gives array of bytes with a given seed.
+/// Create a new farmhash based u64 for an array of bytes with a given seed.
 pub fn hash64_with_seed(s: &[u8], seed: u64) -> u64 {
     xo_hash64_with_seed(s, seed)
 }
 
-/// Create a new farmhash based u64 for a gives array of bytes with 2 given seeds.
+/// Create a new farmhash based u64 for an array of bytes with 2 given seeds.
 pub fn hash64_with_seeds(s: &[u8], seed0: u64, seed1: u64) -> u64 {
     xo_hash64_with_seeds(s, seed0, seed1)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,8 @@ use farmhashxo::xo_hash64_with_seed;
 use farmhashxo::xo_hash64_with_seeds;
 use std::hash::Hasher;
 
-/// Create a new farmhash based u32 for an array of bytes.
+/// Create a new farmhash based u32 for an array of bytes.  Hash value may vary
+/// with library version and platform.
 ///
 /// # Examples
 ///
@@ -27,12 +28,15 @@ use std::hash::Hasher;
 pub fn hash32(s: &[u8]) -> u32 {
     mk_hash32(s)
 }
+
 /// Create a new farmhash based u32 for an array of bytes with a given seed.
+/// Hash value may vary with library version and platform.
 pub fn hash32_with_seed(s: &[u8], seed: u32) -> u32 {
     mk_hash32_with_seed(s, seed)
 }
 
-/// Create a new farmhash based u64 for an array of bytes.
+/// Create a new farmhash based u64 for an array of bytes.  Hash value may
+/// vary with library version and platform.
 ///
 /// # Examples
 ///
@@ -46,16 +50,19 @@ pub fn hash64(s: &[u8]) -> u64 {
 }
 
 /// Create a new farmhash based u64 for an array of bytes with a given seed.
+/// Hash value may vary with library version and platform.
 pub fn hash64_with_seed(s: &[u8], seed: u64) -> u64 {
     xo_hash64_with_seed(s, seed)
 }
 
 /// Create a new farmhash based u64 for an array of bytes with 2 given seeds.
+/// Hash value may vary with library version and platform.
 pub fn hash64_with_seeds(s: &[u8], seed0: u64, seed1: u64) -> u64 {
     xo_hash64_with_seeds(s, seed0, seed1)
 }
 
-/// Create a stable farmhash based u32 for an array of bytes.
+/// Create a new farmhash based u32 for an array of bytes.  Fingerprint value
+/// should be portable and stable across library versions and platforms.
 ///
 /// # Examples
 ///
@@ -68,7 +75,8 @@ pub fn fingerprint32(s: &[u8]) -> u32 {
     mk_hash32(s)
 }
 
-/// Create a stable farmhash based u64 for an array of bytes.
+/// Create a stable farmhash based u64 for an array of bytes.  Fingerprint value
+/// should be portable and stable across library versions and platforms.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
I need stable cross-platform/-implementation hashes, and these functions exposing the specific implementations seem like the intended method for achieving this effect.
