### PR TITLE
Fix overflow-induced panic

### DIFF
--- a/src/farmhashmk.rs
+++ b/src/farmhashmk.rs
@@ -20,7 +20,7 @@ pub fn mk_hash32_with_seed(s: &[u8], seed: u32) -> u32 {
         }
     }
     let h = mk_hask32_len_13_to_24(&s[0 .. 24], seed^(len as u32));
-    return mur(farmhashcc_shared::hash32(&s[24..])+seed, h)
+    return mur(farmhashcc_shared::hash32(&s[24..]).wrapping_add(seed), h)
 }
 
 pub fn mk_hash32(mut s: &[u8]) -> u32{

--- a/src/farmhashmk_shared.rs
+++ b/src/farmhashmk_shared.rs
@@ -39,11 +39,11 @@ pub fn mk_hash32_len_0_to_4 (s: &[u8], seed: u32) -> u32 {
 pub fn mk_hash32_len_5_to_12 (s: &[u8], seed: u32) -> u32 {
     let len = s.len() as usize;
     let mut a = len as u32;
-    let mut b =(len as u32) * 5;
+    let mut b =(len as u32).wrapping_mul(5);
     let mut c: u32 = 9;
-    let d: u32 = b + seed;
-    a += fetch32(&s);
-    b += fetch32(&s[len-4..]);
-    c += fetch32(&s[(len>>1)&4..]);
+    let d: u32 = b.wrapping_add(seed);
+    a = a.wrapping_add(fetch32(&s));
+    b = b.wrapping_add(fetch32(&s[len-4..]));
+    c = c.wrapping_add(fetch32(&s[(len>>1)&4..]));
     return fmix(seed ^ mur(c, mur(b, mur(a, d))))
 }

--- a/src/farmhashmk_shared.rs
+++ b/src/farmhashmk_shared.rs
@@ -14,7 +14,7 @@ pub fn mk_hask32_len_13_to_24 (s: &[u8], seed: u32) -> u32 {
     let d = fetch32(&s[len>>1..]);
     let e = fetch32(&s);
     let f = fetch32(&s[len-4..]);
-    let mut h = d.wrapping_mul(C1) + (len as u32) + seed;
+    let mut h = d.wrapping_mul(C1).wrapping_add(len as u32).wrapping_add(seed);
     a = rotate32(a, 12).wrapping_add(f);
     h = mur(c, h).wrapping_add(a);
     a = rotate32(a, 3).wrapping_add(c);

--- a/tests/test_hash32.rs
+++ b/tests/test_hash32.rs
@@ -102,3 +102,8 @@ fn test_hash32_else() {
         assert_eq!(hash, s.expected);
     }
 }
+
+#[test]
+fn test_hash32_no_overflow() {
+    let _ = hash32_with_seed("trial-0-key-27".as_bytes(), 1);
+}

--- a/tests/test_hash32.rs
+++ b/tests/test_hash32.rs
@@ -105,5 +105,8 @@ fn test_hash32_else() {
 
 #[test]
 fn test_hash32_no_overflow() {
+    let _ = hash32_with_seed("trial-0".as_bytes(), u32::MAX);
     let _ = hash32_with_seed("trial-0-key-27".as_bytes(), 1);
+    let _ = hash32_with_seed("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes(), u32::MAX);
+    let _ = hash32_with_seed(&vec![0xFF; 8], u32::MAX);
 }


### PR DESCRIPTION
At `master`, invoking
```
hash32_with_seed("trial-0-key-27".as_bytes(), 1);
```
will trigger a panic (in debug mode) due to integer overflow:
```
thread 'test_hash32_no_overflow' panicked at 'attempt to add with overflow', src/farmhashmk_shared.rs:17:17
stack backtrace:
   0: rust_begin_unwind
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/panicking.rs:142:14
   2: core::panicking::panic
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/panicking.rs:48:5
   3: farmhash::farmhashmk_shared::mk_hask32_len_13_to_24
             at ./src/farmhashmk_shared.rs:17:17
   4: farmhash::farmhashmk::mk_hash32_with_seed
             at ./src/farmhashmk.rs:15:20
   5: farmhash::hash32_with_seed
             at ./src/lib.rs:35:5
   6: test_hash32::test_hash32_no_overflow
             at ./tests/test_hash32.rs:108:13
   7: test_hash32::test_hash32_no_overflow::{{closure}}
             at ./tests/test_hash32.rs:107:1
   8: core::ops::function::FnOnce::call_once
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/ops/function.rs:248:5
   9: core::ops::function::FnOnce::call_once
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/ops/function.rs:248:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

Most of the other arithmetic operations are explicitly using `wrapping_xyz` variants to avoid this.

While investigating this, I went ahead and did a brief audit of the other 32-bit hash functions for non-wrapping adds, then reverse-engineered inputs that would trigger panics on those. I added test cases as I went, verified that they panic at `master`, then adjusted the code and verified that they now pass.