### PR TITLE
Add rust-toolchain and clean up lints/benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "farmhash"
 version = "1.1.5"
+edition = "2024"
 authors = ["Seif Lotfy <seif.lotfy@gmail.com>"]
 
 # A short blurb about the package. This is not rendered in any format when
@@ -25,5 +26,10 @@ keywords = ["farmhash", "hashing"]
 # be separated with a `/`
 license = "MIT"
 
+[[bench]]
+name = "bench_web2dict"
+harness = false
+
 [dev-dependencies]
-fnv = "1.0.0"
+fnv = "1.0.7"
+criterion = "0.8.1"

--- a/benches/bench_web2dict.rs
+++ b/benches/bench_web2dict.rs
@@ -1,135 +1,274 @@
-#![feature(test)]
-extern crate test;
-extern crate farmhash;
-extern crate fnv;
-
-use self::farmhash::*;
-use self::test::Bencher;
+use criterion::{Criterion, criterion_group, criterion_main};
+use farmhash::{self, FarmHasher};
+use fnv::FnvHasher;
 use std::fs::File;
+use std::hash::{Hash, Hasher};
+use std::hint::black_box;
 use std::io::prelude::*;
 use std::path::Path;
-use std::error::Error;
-use std::hash::{Hash, SipHasher, Hasher};
-use test::black_box;
 
-// Macros to insert into other macros to test with Hash trait or with a direct
-// function
+// Macros to insert into other macros to test with Hash trait or with a direct function
 macro_rules! hash_hashing {
     ($data:ident, $hasher:expr) => {{
         let mut hasher = $hasher;
         $data.hash(&mut hasher);
         black_box(hasher.finish());
-    }}
+    }};
 }
 
 macro_rules! direct_hashing_str {
     ($data:ident, $hasher:expr) => {{
-        black_box($hasher(&$data.as_bytes()));
-    }}
+        black_box($hasher($data.as_bytes()));
+    }};
 }
 
 macro_rules! direct_hashing_u8 {
     ($data:ident, $hasher:expr) => {{
         black_box($hasher($data));
-    }}
+    }};
 }
 
-// Dictonary benchmark
-macro_rules! dict_bench {
-    ($fun:ident, $hashing:ident, $hasher:expr) => {
-        #[bench]
-        fn $fun(b: &mut Bencher) {
-            let path = Path::new("benches/sample-dict");
-            let display = path.display();
+// Dictionary benchmark
+fn bench_dicts(c: &mut Criterion) {
+    let path = Path::new("benches/sample-dict");
+    let display = path.display();
 
-            // Open file in read-only mode
-            let mut file = match File::open(&path) {
-                Err(e) => panic!("Couldn't open '{}': {}", display, e),
-                Ok(file) => file,
-            };
+    // Open file in read-only mode
+    let mut file = match File::open(&path) {
+        Err(e) => panic!("Couldn't open '{}': {}", display, e),
+        Ok(file) => file,
+    };
 
-            // Read all contents to string
-            let mut dict = String::new();
-            if let Err(e) = file.read_to_string(&mut dict) {
-                panic!("Couldn't read '{}': {}", display, e);
-            }
-
-            b.iter(|| {
-                for s in dict.split('\n') {
-                    $hashing!(s, $hasher)
-                }
-            });
-        }
+    // Read all contents to string
+    let mut dict = String::new();
+    if let Err(e) = file.read_to_string(&mut dict) {
+        panic!("Couldn't read '{}': {}", display, e);
     }
+
+    let mut group = c.benchmark_group("dict");
+
+    #[allow(deprecated)]
+    group.bench_function("dict_sip24", |b| {
+        b.iter(|| {
+            for s in dict.split('\n') {
+                hash_hashing!(s, std::hash::SipHasher::default());
+            }
+        });
+    });
+
+    group.bench_function("dict_default_hasher", |b| {
+        b.iter(|| {
+            for s in dict.split('\n') {
+                hash_hashing!(s, std::hash::DefaultHasher::default());
+            }
+        });
+    });
+
+    group.bench_function("dict_fnv", |b| {
+        b.iter(|| {
+            for s in dict.split('\n') {
+                hash_hashing!(s, FnvHasher::default());
+            }
+        });
+    });
+
+    group.bench_function("dict_farm", |b| {
+        b.iter(|| {
+            for s in dict.split('\n') {
+                hash_hashing!(s, FarmHasher::default());
+            }
+        });
+    });
+
+    group.bench_function("dict_farm_direct", |b| {
+        b.iter(|| {
+            for s in dict.split('\n') {
+                direct_hashing_str!(s, farmhash::hash64);
+            }
+        });
+    });
+
+    group.finish();
 }
-
-dict_bench!(bench_dict_sip, hash_hashing, SipHasher::default());
-dict_bench!(bench_dict_fnv, hash_hashing, fnv::FnvHasher::default());
-dict_bench!(bench_dict_farm, hash_hashing, farmhash::FarmHasher::default());
-dict_bench!(bench_dict_farm_direct, direct_hashing_str, farmhash::hash64);
-
 
 // Lorem Ipsum benchmark
-macro_rules! lorem_bench {
-    ($fun:ident, $hashing:ident, $hasher:expr) => {
-        #[bench]
-        fn $fun(b: &mut Bencher) {
-            let data = ["Lorem", "ipsum", "dolor", "sit", "amet,", "consetetur",
-                        "sadipscing", "elitr,", "sed", "diam", "nonumy",
-                        "eirmod", "tempor", "invidunt", "ut", "labore", "et",
-                        "dolore", "magna", "aliquyam", "erat,", "sed", "diam",
-                        "voluptua."];
+fn bench_lorem(c: &mut Criterion) {
+    let data = [
+        "Lorem",
+        "ipsum",
+        "dolor",
+        "sit",
+        "amet,",
+        "consetetur",
+        "sadipscing",
+        "elitr,",
+        "sed",
+        "diam",
+        "nonumy",
+        "eirmod",
+        "tempor",
+        "invidunt",
+        "ut",
+        "labore",
+        "et",
+        "dolore",
+        "magna",
+        "aliquyam",
+        "erat,",
+        "sed",
+        "diam",
+        "voluptua.",
+    ];
 
-            b.iter(|| {
-                for s in &data {
-                    $hashing!(s, $hasher)
-                }
-            });
-        }
-    }
+    let mut group = c.benchmark_group("lorem");
+
+    #[allow(deprecated)]
+    group.bench_function("lorem_sip24", |b| {
+        b.iter(|| {
+            for s in &data {
+                hash_hashing!(s, std::hash::SipHasher::default());
+            }
+        });
+    });
+
+    group.bench_function("lorem_default_hasher", |b| {
+        b.iter(|| {
+            for s in &data {
+                hash_hashing!(s, std::hash::DefaultHasher::default());
+            }
+        });
+    });
+
+    group.bench_function("lorem_fnv", |b| {
+        b.iter(|| {
+            for s in &data {
+                hash_hashing!(s, FnvHasher::default());
+            }
+        });
+    });
+
+    group.bench_function("lorem_farm", |b| {
+        b.iter(|| {
+            for s in &data {
+                hash_hashing!(s, FarmHasher::default());
+            }
+        });
+    });
+
+    group.bench_function("lorem_farm_direct", |b| {
+        b.iter(|| {
+            for s in &data {
+                direct_hashing_str!(s, farmhash::hash64);
+            }
+        });
+    });
+
+    group.finish();
 }
-
-lorem_bench!(bench_lorem_sip, hash_hashing, SipHasher::default());
-lorem_bench!(bench_lorem_fnv, hash_hashing, fnv::FnvHasher::default());
-lorem_bench!(bench_lorem_farm, hash_hashing, farmhash::FarmHasher::default());
-lorem_bench!(bench_lorem_farm_direct, direct_hashing_str, farmhash::hash64);
-
 
 // Pseudo random data benchmark
-macro_rules! lorem_bench {
-    ($fun:ident, $chunk:expr, $hashing:ident, $hasher:expr) => {
-        #[bench]
-        fn $fun(b: &mut Bencher) {
-            let path = Path::new("benches/pseudo-random-data.bin");
-            let display = path.display();
+fn bench_pseudorand(c: &mut Criterion) {
+    let path = Path::new("benches/pseudo-random-data.bin");
+    let display = path.display();
 
-            // Open file in read-only mode
-            let mut file = match File::open(&path) {
-                Err(e) => panic!("Couldn't open '{}': {}", display, e),
-                Ok(file) => file,
-            };
+    // Open file in read-only mode
+    let mut file = match File::open(&path) {
+        Err(e) => panic!("Couldn't open '{}': {}", display, e),
+        Ok(file) => file,
+    };
 
-            // Read all contents to string
-            let mut data = Vec::new();
-            if let Err(e) = file.read_to_end(&mut data) {
-                panic!("Couldn't read '{}': {}", display, e);
-            }
-
-            b.iter(|| {
-                for s in data.chunks($chunk) {
-                    $hashing!(s, $hasher)
-                }
-            });
-        }
+    // Read all contents to vec
+    let mut data = Vec::new();
+    if let Err(e) = file.read_to_end(&mut data) {
+        panic!("Couldn't read '{}': {}", display, e);
     }
+
+    let mut group = c.benchmark_group("pseudo-random");
+
+    #[allow(deprecated)]
+    group.bench_function("pseudorand_big_sip24", |b| {
+        b.iter(|| {
+            for chunk in data.chunks(512) {
+                hash_hashing!(chunk, std::hash::SipHasher::default());
+            }
+        });
+    });
+
+    group.bench_function("pseudorand_big_default_hasher", |b| {
+        b.iter(|| {
+            for chunk in data.chunks(512) {
+                hash_hashing!(chunk, std::hash::DefaultHasher::default());
+            }
+        });
+    });
+
+    group.bench_function("pseudorand_big_fnv", |b| {
+        b.iter(|| {
+            for chunk in data.chunks(512) {
+                hash_hashing!(chunk, FnvHasher::default());
+            }
+        });
+    });
+
+    group.bench_function("pseudorand_big_farm", |b| {
+        b.iter(|| {
+            for chunk in data.chunks(512) {
+                hash_hashing!(chunk, FarmHasher::default());
+            }
+        });
+    });
+
+    group.bench_function("pseudorand_big_farm_direct", |b| {
+        b.iter(|| {
+            for chunk in data.chunks(512) {
+                direct_hashing_u8!(chunk, farmhash::hash64);
+            }
+        });
+    });
+
+    #[allow(deprecated)]
+    group.bench_function("pseudorand_small_sip24", |b| {
+        b.iter(|| {
+            for chunk in data.chunks(4) {
+                hash_hashing!(chunk, std::hash::SipHasher::default());
+            }
+        });
+    });
+
+    group.bench_function("pseudorand_small_default_hasher", |b| {
+        b.iter(|| {
+            for chunk in data.chunks(4) {
+                hash_hashing!(chunk, std::hash::DefaultHasher::default());
+            }
+        });
+    });
+
+    group.bench_function("pseudorand_small_fnv", |b| {
+        b.iter(|| {
+            for chunk in data.chunks(4) {
+                hash_hashing!(chunk, FnvHasher::default());
+            }
+        });
+    });
+
+    group.bench_function("pseudorand_small_farm", |b| {
+        b.iter(|| {
+            for chunk in data.chunks(4) {
+                hash_hashing!(chunk, FarmHasher::default());
+            }
+        });
+    });
+
+    group.bench_function("pseudorand_small_farm_direct", |b| {
+        b.iter(|| {
+            for chunk in data.chunks(4) {
+                direct_hashing_u8!(chunk, farmhash::hash64);
+            }
+        });
+    });
+
+    group.finish();
 }
 
-lorem_bench!(bench_pseurand_big_sip, 512, hash_hashing, SipHasher::default());
-lorem_bench!(bench_pseurand_big_fnv, 512, hash_hashing, fnv::FnvHasher::default());
-lorem_bench!(bench_pseurand_big_farm, 512, hash_hashing, farmhash::FarmHasher::default());
-lorem_bench!(bench_pseurand_big_farm_direct, 512, direct_hashing_u8, farmhash::hash64);
-
-lorem_bench!(bench_pseurand_small_sip, 4, hash_hashing, SipHasher::default());
-lorem_bench!(bench_pseurand_small_fnv, 4, hash_hashing, fnv::FnvHasher::default());
-lorem_bench!(bench_pseurand_small_farm, 4, hash_hashing, farmhash::FarmHasher::default());
-lorem_bench!(bench_pseurand_small_farm_direct, 4, direct_hashing_u8, farmhash::hash64);
+criterion_group!(benches, bench_dicts, bench_lorem, bench_pseudorand);
+criterion_main!(benches);

--- a/benches/bench_web2dict.rs
+++ b/benches/bench_web2dict.rs
@@ -88,6 +88,14 @@ fn bench_dicts(c: &mut Criterion) {
         });
     });
 
+    group.bench_function("dict_farm_fingerprint64", |b| {
+        b.iter(|| {
+            for s in dict.split('\n') {
+                direct_hashing_str!(s, farmhash::fingerprint64);
+            }
+        });
+    });
+
     group.finish();
 }
 
@@ -163,6 +171,14 @@ fn bench_lorem(c: &mut Criterion) {
         });
     });
 
+    group.bench_function("lorem_farm_fingerprint64", |b| {
+        b.iter(|| {
+            for s in &data {
+                direct_hashing_str!(s, farmhash::fingerprint64);
+            }
+        });
+    });
+
     group.finish();
 }
 
@@ -226,6 +242,14 @@ fn bench_pseudorand(c: &mut Criterion) {
         });
     });
 
+    group.bench_function("pseudorand_big_farm_fingerprint64", |b| {
+        b.iter(|| {
+            for chunk in data.chunks(512) {
+                direct_hashing_u8!(chunk, farmhash::fingerprint64);
+            }
+        });
+    });
+
     #[allow(deprecated)]
     group.bench_function("pseudorand_small_sip24", |b| {
         b.iter(|| {
@@ -263,6 +287,14 @@ fn bench_pseudorand(c: &mut Criterion) {
         b.iter(|| {
             for chunk in data.chunks(4) {
                 direct_hashing_u8!(chunk, farmhash::hash64);
+            }
+        });
+    });
+
+    group.bench_function("pseudorand_small_farm_fingerprint64", |b| {
+        b.iter(|| {
+            for chunk in data.chunks(4) {
+                direct_hashing_u8!(chunk, farmhash::fingerprint64);
             }
         });
     });

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.91.1"
+components = ["rustfmt", "clippy"]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+# Maximum width of each line.
+# Default: 100
+# https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#max_width
+max_width = 120

--- a/src/farmhashcc_shared.rs
+++ b/src/farmhashcc_shared.rs
@@ -4,103 +4,101 @@
 // and a 128-bit hash equivalent to CityHash128 (v1.1.1).  It also provides
 // a seeded 32-bit hash function similar to CityHash32.
 
-use platform::*;
+use crate::platform::*;
 use std::mem;
 
 fn hash32_len_13_to_24(s: &[u8]) -> u32 {
-    let len = s.len() as usize;
-    let a = fetch32(&s[(len>>1 as u64) - 4..]);
+    let len = s.len();
+    let a = fetch32(&s[(len >> 1u64) - 4..]);
     let b = fetch32(&s[4..]);
-    let c = fetch32(&s[len-8..]);
-    let d = fetch32(&s[len>>1..]);
+    let c = fetch32(&s[len - 8..]);
+    let d = fetch32(&s[len >> 1..]);
     let e = fetch32(&s[0..]);
-    let f = fetch32(&s[len-4..]);
+    let f = fetch32(&s[len - 4..]);
     let h = len as u32;
-    return fmix(mur(f, mur(e, mur(d, mur(c, mur(b, mur(a, h)))))));
+    fmix(mur(f, mur(e, mur(d, mur(c, mur(b, mur(a, h)))))))
 }
 
 fn hash32_len_0_to_4(s: &[u8]) -> u32 {
-    let len = s.len() as usize;
+    let len = s.len();
     let mut b: u32 = 0;
     let mut c: u32 = 9;
-    for i in 0..len {
-        let v: u8 = s[i];
+    for &v in s {
         b = b.wrapping_mul(C1) + v as u32;
         c ^= b;
     }
-    return fmix(mur(b, mur(len as u32, c)));
+    fmix(mur(b, mur(len as u32, c)))
 }
 
 fn hash32_len_5_to_12(s: &[u8]) -> u32 {
-    let len = s.len() as usize;
+    let len = s.len();
     let mut a = len as u32;
     let mut b = len as u32 * 5;
     let mut c: u32 = 9;
     let d: u32 = b;
 
     a += fetch32(&s[0..]);
-    b += fetch32(&s[len-4..]);
+    b += fetch32(&s[len - 4..]);
     c += fetch32(&s[((len >> 1) & 4)..]);
-    return fmix(mur(c, mur(b, mur(a, d))));
+    fmix(mur(c, mur(b, mur(a, d))))
 }
 
-
 pub fn hash32(mut s: &[u8]) -> u32 {
-    let len = s.len() as usize;
+    let len = s.len();
     if len <= 24 {
         if len <= 12 {
             if len <= 4 {
-                return hash32_len_0_to_4(s)
+                return hash32_len_0_to_4(s);
             }
-            return hash32_len_5_to_12(s)
+            return hash32_len_5_to_12(s);
         }
-        return hash32_len_13_to_24(s)
+        return hash32_len_13_to_24(s);
     }
 
     // len > 24
     let mut h = len as u32;
     let mut g = (len as u32).wrapping_mul(C1);
     let mut f = g;
-    let a0 = rotate32(fetch32(&s[(len-4)..]).wrapping_mul(C1), 17) * C2;
-    let a1 = rotate32(fetch32(&s[(len-8)..]).wrapping_mul(C1), 17) * C2;
-    let a2 = rotate32(fetch32(&s[(len-16)..]).wrapping_mul(C1), 17) * C2;
-    let a3 = rotate32(fetch32(&s[(len-12)..]).wrapping_mul(C1), 17) * C2;
-    let a4 = rotate32(fetch32(&s[(len-20)..]).wrapping_mul(C1), 17) * C2;
+    let a0 = rotate32(fetch32(&s[(len - 4)..]).wrapping_mul(C1), 17) * C2;
+    let a1 = rotate32(fetch32(&s[(len - 8)..]).wrapping_mul(C1), 17) * C2;
+    let a2 = rotate32(fetch32(&s[(len - 16)..]).wrapping_mul(C1), 17) * C2;
+    let a3 = rotate32(fetch32(&s[(len - 12)..]).wrapping_mul(C1), 17) * C2;
+    let a4 = rotate32(fetch32(&s[(len - 20)..]).wrapping_mul(C1), 17) * C2;
     h ^= a0;
     h = rotate32(h, 19);
-    h = (h*5).wrapping_add(0xe6546b64);
+    h = (h * 5).wrapping_add(0xe6546b64);
     h ^= a2;
     h = rotate32(h, 19);
-    h = (h*5).wrapping_add(0xe6546b64);
+    h = (h * 5).wrapping_add(0xe6546b64);
     g ^= a1;
     g = rotate32(g, 19);
-    g = (g*5).wrapping_add(0xe6546b64);
+    g = (g * 5).wrapping_add(0xe6546b64);
     g ^= a3;
     g = rotate32(g, 19);
-    g = (g*5).wrapping_add(0xe6546b64);
+    g = (g * 5).wrapping_add(0xe6546b64);
     f += a4;
     f = rotate32(f, 19);
-    f = (f*5).wrapping_add(0xe6546b64);
+    f = (f * 5).wrapping_add(0xe6546b64);
 
     let mut iters = ((len - 1) / 20) as u64;
-    while iters > 0{
-        let a0 = rotate32(fetch32(&s[..]).wrapping_mul(C1), 17).wrapping_mul(C2);
+    while iters > 0 {
+        let a0 = rotate32(fetch32(s).wrapping_mul(C1), 17).wrapping_mul(C2);
         let a1 = fetch32(&s[4..]);
         let a2 = rotate32(fetch32(&s[8..]).wrapping_mul(C1), 17).wrapping_mul(C2);
         let a3 = rotate32(fetch32(&s[12..]).wrapping_mul(C1), 17).wrapping_mul(C2);
         let a4 = fetch32(&s[16..]);
         h ^= a0;
         h = rotate32(h, 18);
-        h = (h*5).wrapping_add(0xe6546b64);
+        h = (h * 5).wrapping_add(0xe6546b64);
         f += a1;
         f = rotate32(f, 19);
         f = f.wrapping_mul(C1);
         g += a2;
         g = rotate32(g, 18);
-        g = (g*5).wrapping_add(0xe6546b64);
+        g = (g * 5).wrapping_add(0xe6546b64);
         h ^= a3 + a1;
         h = rotate32(h, 19);
-        h = (h*5).wrapping_add(0xe6546b64);
+        h = (h * 5).wrapping_add(0xe6546b64);
         g ^= a4;
         g = bswap32(g) * 5;
         h += a4 * 5;
@@ -111,41 +109,46 @@ pub fn hash32(mut s: &[u8]) -> u32 {
 
         mem::swap(&mut g, &mut f);
         s = &s[20..];
-        iters-=1;
+        iters -= 1;
     }
     g = rotate32(g, 11).wrapping_mul(C1);
     g = rotate32(g, 17).wrapping_mul(C1);
     f = rotate32(f, 11).wrapping_mul(C1);
     f = rotate32(f, 17).wrapping_mul(C1);
-    h = rotate32(h+g, 19);
-    h = h*5 + 0xe6546b64;
+    h = rotate32(h + g, 19);
+    h = h * 5 + 0xe6546b64;
     h = rotate32(h, 17).wrapping_mul(C1);
-    h = rotate32(h+f, 19);
-    h = h*5 + 0xe6546b64;
+    h = rotate32(h + f, 19);
+    h = h * 5 + 0xe6546b64;
     h = rotate32(h, 17).wrapping_mul(C1);
-    return h
+    h
 }
 
 // Return a 16-byte hash for 48 bytes.  Quick and dirty.
 // Callers do best to use "random-looking" values for a and b.
 // Note: C++ returned pair<uint64_t, uint64_t>
-pub fn weak_hash_len_32_with_seeds(w: u64, x: u64, y:u64, z:u64, mut a:u64, mut b:u64) -> Uint128 {
+pub fn weak_hash_len_32_with_seeds(w: u64, x: u64, y: u64, z: u64, mut a: u64, mut b: u64) -> Uint128 {
     a = a.wrapping_add(w);
     b = rotate64(b.wrapping_add(a).wrapping_add(z), 21);
     let c = a;
     a = a.wrapping_add(x);
     a = a.wrapping_add(y);
     b = b.wrapping_add(rotate64(a, 44));
-    return Uint128{first: a.wrapping_add(z), second:b.wrapping_add(c)};
+    Uint128 {
+        first: a.wrapping_add(z),
+        second: b.wrapping_add(c),
+    }
 }
 
 // Return a 16-byte hash for s[0] ... s[31], a, and b.  Quick and dirty.
 // Note: original C++ returned a pair<uint64_t, uint64_t>
-pub fn weak_hash_len_32_with_seeds_bytes(s: &[u8], a:u64, b:u64) -> Uint128 {
-    return weak_hash_len_32_with_seeds(fetch64(&s[0..8]),
+pub fn weak_hash_len_32_with_seeds_bytes(s: &[u8], a: u64, b: u64) -> Uint128 {
+    weak_hash_len_32_with_seeds(
+        fetch64(&s[0..8]),
         fetch64(&s[8..16]),
         fetch64(&s[16..24]),
         fetch64(&s[24..32]),
         a,
-        b);
+        b,
+    )
 }

--- a/src/farmhashmk.rs
+++ b/src/farmhashmk.rs
@@ -4,47 +4,47 @@
 // Some only differ by taking a seed but others are quite different
 // To avoid clashes I've added mk to the start of these names
 
-use platform::*;
-use farmhashcc_shared;
-use farmhashmk_shared::*;
+use crate::farmhashcc_shared;
+use crate::farmhashmk_shared::*;
+use crate::platform::*;
 
 pub fn mk_hash32_with_seed(s: &[u8], seed: u32) -> u32 {
-    let len = s.len() as usize;
+    let len = s.len();
     if len <= 24 {
         if len >= 13 {
-            return mk_hask32_len_13_to_24(s, seed.wrapping_mul(C1))
+            return mk_hask32_len_13_to_24(s, seed.wrapping_mul(C1));
         } else if len >= 5 {
-            return mk_hash32_len_5_to_12(s, seed)
+            return mk_hash32_len_5_to_12(s, seed);
         } else {
-            return mk_hash32_len_0_to_4(s, seed)
+            return mk_hash32_len_0_to_4(s, seed);
         }
     }
-    let h = mk_hask32_len_13_to_24(&s[0 .. 24], seed^(len as u32));
-    return mur(farmhashcc_shared::hash32(&s[24..])+seed, h)
+    let h = mk_hask32_len_13_to_24(&s[0..24], seed ^ (len as u32));
+    mur(farmhashcc_shared::hash32(&s[24..]) + seed, h)
 }
 
-pub fn mk_hash32(mut s: &[u8]) -> u32{
-    let len = s.len() as usize;
+pub fn mk_hash32(mut s: &[u8]) -> u32 {
+    let len = s.len();
     if len <= 24 {
         if len <= 12 {
             if len <= 4 {
-                return mk_hash32_len_0_to_4(s, 0)
+                return mk_hash32_len_0_to_4(s, 0);
             }
-            return mk_hash32_len_5_to_12(s, 0)
+            return mk_hash32_len_5_to_12(s, 0);
         }
-        return mk_hask32_len_13_to_24(s, 0)
+        return mk_hask32_len_13_to_24(s, 0);
     }
 
     // len > 24
     //var h, g, f uint32
     let mut h = len as u32;
-    let mut g  = (len as u32).wrapping_mul(C1);
+    let mut g = (len as u32).wrapping_mul(C1);
     let mut f: u32 = g;
-    let a0 = rotate32(fetch32(&s[len-4..]).wrapping_mul(C1), 17).wrapping_mul(C2);
-    let a1 = rotate32(fetch32(&s[len-8..]).wrapping_mul(C1), 17).wrapping_mul(C2);
-    let a2 = rotate32(fetch32(&s[len-16..]).wrapping_mul(C1), 17).wrapping_mul(C2);
-    let a3 = rotate32(fetch32(&s[len-12..]).wrapping_mul(C1), 17).wrapping_mul(C2);
-    let a4 = rotate32(fetch32(&s[len-20..]).wrapping_mul(C1), 17).wrapping_mul(C2);
+    let a0 = rotate32(fetch32(&s[len - 4..]).wrapping_mul(C1), 17).wrapping_mul(C2);
+    let a1 = rotate32(fetch32(&s[len - 8..]).wrapping_mul(C1), 17).wrapping_mul(C2);
+    let a2 = rotate32(fetch32(&s[len - 16..]).wrapping_mul(C1), 17).wrapping_mul(C2);
+    let a3 = rotate32(fetch32(&s[len - 12..]).wrapping_mul(C1), 17).wrapping_mul(C2);
+    let a4 = rotate32(fetch32(&s[len - 20..]).wrapping_mul(C1), 17).wrapping_mul(C2);
     h ^= a0;
     h = rotate32(h, 19);
     h = h.wrapping_mul(5).wrapping_add(0xe6546b64);
@@ -61,7 +61,7 @@ pub fn mk_hash32(mut s: &[u8]) -> u32{
     f = rotate32(f, 19).wrapping_add(113);
     let mut iters = ((len - 1) / 20) as u64;
     while iters > 0 {
-        let a = fetch32(&s);
+        let a = fetch32(s);
         let b = fetch32(&s[4..]);
         let c = fetch32(&s[8..]);
         let d = fetch32(&s[12..]);
@@ -75,7 +75,7 @@ pub fn mk_hash32(mut s: &[u8]) -> u32{
         f = f.wrapping_add(g);
         g = g.wrapping_add(f);
         s = &s[20..];
-        iters-=1;
+        iters -= 1;
     }
     g = rotate32(g, 11).wrapping_mul(C1);
     g = rotate32(g, 17).wrapping_mul(C1);
@@ -85,7 +85,7 @@ pub fn mk_hash32(mut s: &[u8]) -> u32{
     h = h.wrapping_mul(5).wrapping_add(0xe6546b64);
     h = rotate32(h, 17).wrapping_mul(C1);
     h = rotate32(h.wrapping_add(f), 19);
-    h =  h.wrapping_mul(5).wrapping_add(0xe6546b64);
+    h = h.wrapping_mul(5).wrapping_add(0xe6546b64);
     h = rotate32(h, 17).wrapping_mul(C1);
-    return h
+    h
 }

--- a/src/farmhashmk_shared.rs
+++ b/src/farmhashmk_shared.rs
@@ -4,46 +4,45 @@
 // Some only differ by taking a seed but others are quite different
 // To avoid clashes I've added mk to the start of these names
 
-use platform::*;
+use crate::platform::*;
 
-pub fn mk_hask32_len_13_to_24 (s: &[u8], seed: u32) -> u32 {
-    let len = s.len() as usize;
-    let mut a = fetch32(&s[(len>>1)-4..]);
+pub fn mk_hask32_len_13_to_24(s: &[u8], seed: u32) -> u32 {
+    let len = s.len();
+    let mut a = fetch32(&s[(len >> 1) - 4..]);
     let b = fetch32(&s[4..]);
-    let c = fetch32(&s[len-8..]);
-    let d = fetch32(&s[len>>1..]);
-    let e = fetch32(&s);
-    let f = fetch32(&s[len-4..]);
+    let c = fetch32(&s[len - 8..]);
+    let d = fetch32(&s[len >> 1..]);
+    let e = fetch32(s);
+    let f = fetch32(&s[len - 4..]);
     let mut h = d.wrapping_mul(C1) + (len as u32) + seed;
     a = rotate32(a, 12).wrapping_add(f);
     h = mur(c, h).wrapping_add(a);
     a = rotate32(a, 3).wrapping_add(c);
     h = mur(e, h).wrapping_add(a);
     a = rotate32(a.wrapping_add(f), 12).wrapping_add(d);
-    h = mur(b^seed, h).wrapping_add(a);
-    return fmix(h);
+    h = mur(b ^ seed, h).wrapping_add(a);
+    fmix(h)
 }
 
-pub fn mk_hash32_len_0_to_4 (s: &[u8], seed: u32) -> u32 {
-    let len = s.len() as usize;
+pub fn mk_hash32_len_0_to_4(s: &[u8], seed: u32) -> u32 {
+    let len = s.len();
     let mut b = seed;
     let mut c: u32 = 9;
-    for i in 0..len{
-        let v = s[i] as u8;
+    for &v in s {
         b = b.wrapping_mul(C1).wrapping_add(v as u32);
         c ^= b;
     }
-    return fmix(mur(b, mur((len as u32), c)))
+    fmix(mur(b, mur(len as u32, c)))
 }
 
-pub fn mk_hash32_len_5_to_12 (s: &[u8], seed: u32) -> u32 {
-    let len = s.len() as usize;
+pub fn mk_hash32_len_5_to_12(s: &[u8], seed: u32) -> u32 {
+    let len = s.len();
     let mut a = len as u32;
-    let mut b =(len as u32) * 5;
+    let mut b = (len as u32) * 5;
     let mut c: u32 = 9;
     let d: u32 = b + seed;
-    a += fetch32(&s);
-    b += fetch32(&s[len-4..]);
-    c += fetch32(&s[(len>>1)&4..]);
-    return fmix(seed ^ mur(c, mur(b, mur(a, d))))
+    a += fetch32(s);
+    b += fetch32(&s[len - 4..]);
+    c += fetch32(&s[(len >> 1) & 4..]);
+    fmix(seed ^ mur(c, mur(b, mur(a, d))))
 }

--- a/src/farmhashna.rs
+++ b/src/farmhashna.rs
@@ -1,12 +1,12 @@
 // Based on the original C++ farmhashna.cc
-use platform::*;
-use farmhashna_shared::*;
-use farmhashcc_shared;
+use crate::farmhashcc_shared;
+use crate::farmhashna_shared::*;
+use crate::platform::*;
 use std::mem;
 
 // renamed from hash64 to make it clearer elsewhere which is being called
 pub fn na_hash64(mut s: &[u8]) -> u64 {
-    let len = s.len() as usize;
+    let len = s.len();
     const SEED: u64 = 81;
     if len <= 32 {
         if len <= 16 {
@@ -14,7 +14,7 @@ pub fn na_hash64(mut s: &[u8]) -> u64 {
         } else {
             return hash_len_17_to_32(s);
         }
-    } else if len <= 64{
+    } else if len <= 64 {
         return hash_len_33_to_64(s);
     }
     // For strings over 64 bytes we loop.  Internal state consists of
@@ -22,20 +22,28 @@ pub fn na_hash64(mut s: &[u8]) -> u64 {
     let mut x = SEED;
     let mut y: u64 = 2480279821605975764; // y := (seed*k1) + 113
     let mut z = shift_mix(y.wrapping_mul(K2).wrapping_add(113)).wrapping_mul(K2);
-    let mut v = Uint128 {first:0, second:0};
-    let mut w = Uint128 {first:0, second:0};
+    let mut v = Uint128 { first: 0, second: 0 };
+    let mut w = Uint128 { first: 0, second: 0 };
 
     x = x.wrapping_mul(K2).wrapping_add(fetch64(s));
 
     let last64 = &s[len - 64..];
     while {
-        x = rotate64(x.wrapping_add(y).wrapping_add(v.first).wrapping_add(fetch64(&s[8..])), 37).wrapping_mul(K1);
+        x = rotate64(
+            x.wrapping_add(y).wrapping_add(v.first).wrapping_add(fetch64(&s[8..])),
+            37,
+        )
+        .wrapping_mul(K1);
         y = rotate64(y.wrapping_add(v.second).wrapping_add(fetch64(&s[48..])), 42).wrapping_mul(K1);
         x ^= w.second;
         y = y.wrapping_add(v.first).wrapping_add(fetch64(&s[40..]));
         z = rotate64(z.wrapping_add(w.first), 33).wrapping_mul(K1);
-        v = farmhashcc_shared::weak_hash_len_32_with_seeds_bytes(&s,v.second.wrapping_mul(K1), x.wrapping_add(w.first));
-        w = farmhashcc_shared::weak_hash_len_32_with_seeds_bytes(&s[32..],z.wrapping_add(w.second), y.wrapping_add(fetch64(&s[16..])));
+        v = farmhashcc_shared::weak_hash_len_32_with_seeds_bytes(s, v.second.wrapping_mul(K1), x.wrapping_add(w.first));
+        w = farmhashcc_shared::weak_hash_len_32_with_seeds_bytes(
+            &s[32..],
+            z.wrapping_add(w.second),
+            y.wrapping_add(fetch64(&s[16..])),
+        );
 
         mem::swap(&mut z, &mut x);
         s = &s[64..];
@@ -46,29 +54,36 @@ pub fn na_hash64(mut s: &[u8]) -> u64 {
 
     // Make s point to the last 64 bytes of input.
     s = last64;
-    w.first = w.first.wrapping_add(((len as u64 - 1) & 63));
+    w.first = w.first.wrapping_add((len as u64 - 1) & 63);
     v.first = v.first.wrapping_add(w.first);
     w.first = w.first.wrapping_add(v.first);
-    x = rotate64(x.wrapping_add(y)
-        .wrapping_add(v.first.wrapping_add(fetch64(&s[8..]))), 37).wrapping_mul(mul);
+    x = rotate64(
+        x.wrapping_add(y).wrapping_add(v.first.wrapping_add(fetch64(&s[8..]))),
+        37,
+    )
+    .wrapping_mul(mul);
     y = rotate64(y.wrapping_add(v.second).wrapping_add(fetch64(&s[48..])), 42).wrapping_mul(mul);
     x ^= w.second.wrapping_mul(9);
     y = y.wrapping_add(v.first.wrapping_mul(9).wrapping_add(fetch64(&s[40..])));
     z = rotate64(z.wrapping_add(w.first), 33).wrapping_mul(mul);
-    v = farmhashcc_shared::weak_hash_len_32_with_seeds_bytes(&s, v.second.wrapping_mul(mul),
-        x.wrapping_add(w.first));
-    w = farmhashcc_shared::weak_hash_len_32_with_seeds_bytes(&s[32..], z.wrapping_add(w.second),
-        y.wrapping_add(fetch64(&s[16..])));
+    v = farmhashcc_shared::weak_hash_len_32_with_seeds_bytes(s, v.second.wrapping_mul(mul), x.wrapping_add(w.first));
+    w = farmhashcc_shared::weak_hash_len_32_with_seeds_bytes(
+        &s[32..],
+        z.wrapping_add(w.second),
+        y.wrapping_add(fetch64(&s[16..])),
+    );
     mem::swap(&mut z, &mut x);
-    return hash_len_16_mul(hash_len_16_mul(v.first, w.first, mul).wrapping_add(shift_mix(y).wrapping_mul(K0).wrapping_add(z)),
+    hash_len_16_mul(
+        hash_len_16_mul(v.first, w.first, mul).wrapping_add(shift_mix(y).wrapping_mul(K0).wrapping_add(z)),
         hash_len_16_mul(v.second, w.second, mul).wrapping_add(x),
-        mul)
+        mul,
+    )
 }
 
 pub fn na_hash64_with_seed(s: &[u8], seed: u64) -> u64 {
-    return na_hash64_with_seeds(s, K2, seed)
+    na_hash64_with_seeds(s, K2, seed)
 }
 
 pub fn na_hash64_with_seeds(s: &[u8], seed0: u64, seed1: u64) -> u64 {
-    return hash_len_16(na_hash64(s).wrapping_sub(seed0), seed1)
+    hash_len_16(na_hash64(s).wrapping_sub(seed0), seed1)
 }

--- a/src/farmhashna_shared.rs
+++ b/src/farmhashna_shared.rs
@@ -1,4 +1,4 @@
-use platform::*;
+use crate::platform::*;
 
 pub fn shift_mix(val: u64) -> u64 {
     val ^ (val >> 47)
@@ -10,19 +10,19 @@ pub fn hash_len_16_mul(u: u64, v: u64, mul: u64) -> u64 {
     let mut b = (v ^ a).wrapping_mul(mul);
     b ^= b >> 47;
     b = b.wrapping_mul(mul);
-    return b;
+    b
 }
 
-pub fn hash_len_16(u: u64, v: u64) -> u64{
-    hash128to64(Uint128{first: u, second: v})
+pub fn hash_len_16(u: u64, v: u64) -> u64 {
+    hash128to64(Uint128 { first: u, second: v })
 }
 
 pub fn hash_len_0_to_16(s: &[u8]) -> u64 {
-    let len = s.len() as usize;
+    let len = s.len();
     if len >= 8 {
-        let mul = K2.wrapping_add(len as u64 *2);
+        let mul = K2.wrapping_add(len as u64 * 2);
         let a = fetch64(s).wrapping_add(K2);
-        let b = fetch64(&s[len - 8 ..]);
+        let b = fetch64(&s[len - 8..]);
         let c = rotate64(b, 37).wrapping_mul(mul).wrapping_add(a);
         let d = rotate64(a, 25).wrapping_add(b).wrapping_mul(mul);
         return hash_len_16_mul(c, d, mul);
@@ -30,7 +30,7 @@ pub fn hash_len_0_to_16(s: &[u8]) -> u64 {
     if len >= 4 {
         let mul = K2 + len as u64 * 2;
         let a = fetch32(s);
-        return hash_len_16_mul(len as u64 + ((a as u64) << 3), fetch32(&s[len-4..]) as u64, mul);
+        return hash_len_16_mul(len as u64 + ((a as u64) << 3), fetch32(&s[len - 4..]) as u64, mul);
     }
     if len > 0 {
         let a = s[0];
@@ -40,36 +40,46 @@ pub fn hash_len_0_to_16(s: &[u8]) -> u64 {
         let z = len as u64 + ((c as u64) << 2);
         return shift_mix((y as u64).wrapping_mul(K2) ^ z.wrapping_mul(K0)).wrapping_mul(K2);
     }
-    return K2;
+    K2
 }
 
 // This probably works well for 16-byte strings as well, but it may be overkill
 // in that case.
 pub fn hash_len_17_to_32(s: &[u8]) -> u64 {
-    let len = s.len() as usize;
-    let mul = K2.wrapping_add((len as u64)*2);
-    let a = fetch64(&s).wrapping_mul(K1);
+    let len = s.len();
+    let mul = K2.wrapping_add((len as u64) * 2);
+    let a = fetch64(s).wrapping_mul(K1);
     let b = fetch64(&s[8..]);
-    let c = fetch64(&s[len-8..]).wrapping_mul(mul);
-    let d = fetch64(&s[len-16..]).wrapping_mul(K2);
-    return hash_len_16_mul(rotate64(a.wrapping_add(b), 43).wrapping_add(rotate64(c, 30)).wrapping_add(d),
-        (a.wrapping_add(rotate64(b.wrapping_add(K2), 18))).wrapping_add(c), mul);
+    let c = fetch64(&s[len - 8..]).wrapping_mul(mul);
+    let d = fetch64(&s[len - 16..]).wrapping_mul(K2);
+    hash_len_16_mul(
+        rotate64(a.wrapping_add(b), 43)
+            .wrapping_add(rotate64(c, 30))
+            .wrapping_add(d),
+        (a.wrapping_add(rotate64(b.wrapping_add(K2), 18))).wrapping_add(c),
+        mul,
+    )
 }
 
 // Return an 8-byte hash for 33 to 64 bytes.
 pub fn hash_len_33_to_64(s: &[u8]) -> u64 {
-    let len = s.len() as usize;
+    let len = s.len();
     let mul = K2.wrapping_add((len as u64) * 2);
-    let a = fetch64(&s).wrapping_mul(K2);
+    let a = fetch64(s).wrapping_mul(K2);
     let b = fetch64(&s[8..]);
-    let c = fetch64(&s[len-8..]).wrapping_mul(mul);
-    let d = fetch64(&s[len-16..]).wrapping_mul(K2);
-    let y = rotate64(a.wrapping_add(b), 43).wrapping_add(rotate64(c, 30)).wrapping_add(d);
+    let c = fetch64(&s[len - 8..]).wrapping_mul(mul);
+    let d = fetch64(&s[len - 16..]).wrapping_mul(K2);
+    let y = rotate64(a.wrapping_add(b), 43)
+        .wrapping_add(rotate64(c, 30))
+        .wrapping_add(d);
     let z = hash_len_16_mul(y, a.wrapping_add(rotate64(b.wrapping_add(K2), 18)).wrapping_add(c), mul);
     let e = fetch64(&s[16..]).wrapping_mul(mul);
     let f = fetch64(&s[24..]);
-    let g = (y.wrapping_add(fetch64(&s[len-32..]))).wrapping_mul(mul);
-    let h = (z.wrapping_add(fetch64(&s[len-24..]))).wrapping_mul(mul);
-    return hash_len_16_mul(rotate64(e.wrapping_add(f), 43).wrapping_add(rotate64(g, 30).wrapping_add(h)),
-        e.wrapping_add(rotate64(f.wrapping_add(a), 18).wrapping_add(g)), mul);
+    let g = (y.wrapping_add(fetch64(&s[len - 32..]))).wrapping_mul(mul);
+    let h = (z.wrapping_add(fetch64(&s[len - 24..]))).wrapping_mul(mul);
+    hash_len_16_mul(
+        rotate64(e.wrapping_add(f), 43).wrapping_add(rotate64(g, 30).wrapping_add(h)),
+        e.wrapping_add(rotate64(f.wrapping_add(a), 18).wrapping_add(g)),
+        mul,
+    )
 }

--- a/src/farmhashuo.rs
+++ b/src/farmhashuo.rs
@@ -1,29 +1,32 @@
-use platform::*;
-use farmhashna::*;
-use farmhashna_shared::*;
-use farmhashcc_shared::weak_hash_len_32_with_seeds_bytes;
+use crate::farmhashcc_shared::weak_hash_len_32_with_seeds_bytes;
+use crate::farmhashna::*;
+use crate::farmhashna_shared::*;
+use crate::platform::*;
 use std::mem;
 
 fn uo_h(x: u64, y: u64, mul: u64, r: u64) -> u64 {
     let mut a = (x ^ y).wrapping_mul(mul);
     a ^= a >> 47;
     let b = (y ^ a).wrapping_mul(mul);
-    return rotate64(b, r).wrapping_mul(mul);
+    rotate64(b, r).wrapping_mul(mul)
 }
 
 pub fn uo_hash64_with_seeds(mut s: &[u8], seed0: u64, seed1: u64) -> u64 {
-    let len = s.len() as usize;
+    let len = s.len();
     if len <= 64 {
-        return na_hash64_with_seeds(s, seed0, seed1)
+        return na_hash64_with_seeds(s, seed0, seed1);
     }
 
     // For strings over 64 bytes we loop.  Internal state consists of
     // 64 bytes: u, v, w, x, y, and z.
     let mut x = seed0;
     let mut y = seed1.wrapping_mul(K1).wrapping_add(113);
-    let mut z =  shift_mix(y.wrapping_mul(K2)).wrapping_mul(K2);
-    let mut v = Uint128{first: seed0, second: seed1};
-    let mut w = Uint128{first: 0, second: 0};
+    let mut z = shift_mix(y.wrapping_mul(K2)).wrapping_mul(K2);
+    let mut v = Uint128 {
+        first: seed0,
+        second: seed1,
+    };
+    let mut w = Uint128 { first: 0, second: 0 };
     let mut u = x.wrapping_sub(z);
     x = x.wrapping_mul(K2);
     let mul = K2.wrapping_add(u & 0x82);
@@ -89,11 +92,15 @@ pub fn uo_hash64_with_seeds(mut s: &[u8], seed0: u64, seed1: u64) -> u64 {
     u = u.wrapping_mul(9);
     v.second = rotate64(v.second, 28);
     v.first = rotate64(v.first, 20);
-    w.first = w.first.wrapping_add((len-1) as u64 & 63);
+    w.first = w.first.wrapping_add((len - 1) as u64 & 63);
     u = u.wrapping_add(y);
     y = y.wrapping_add(u);
-    x = rotate64(y.wrapping_sub(x).wrapping_add(v.first).wrapping_add(fetch64(&s[8..])), 37).wrapping_mul(mul);
-    y = rotate64(y^v.second^fetch64(&s[48..]), 42).wrapping_mul(mul);
+    x = rotate64(
+        y.wrapping_sub(x).wrapping_add(v.first).wrapping_add(fetch64(&s[8..])),
+        37,
+    )
+    .wrapping_mul(mul);
+    y = rotate64(y ^ v.second ^ fetch64(&s[48..]), 42).wrapping_mul(mul);
 
     x ^= w.second.wrapping_mul(9);
     y = y.wrapping_add(v.first).wrapping_add(fetch64(&s[40..]));
@@ -101,22 +108,26 @@ pub fn uo_hash64_with_seeds(mut s: &[u8], seed0: u64, seed1: u64) -> u64 {
 
     v = weak_hash_len_32_with_seeds_bytes(s, v.second.wrapping_mul(mul), x.wrapping_add(w.first));
     w = weak_hash_len_32_with_seeds_bytes(&s[32..], z.wrapping_add(w.second), y.wrapping_add(fetch64(&s[16..])));
-    return uo_h(hash_len_16_mul(v.first.wrapping_add(x), w.first^y, mul).wrapping_add(z).wrapping_sub(u),
-        uo_h(v.second.wrapping_add(y), w.second.wrapping_add(z), K2, 30)^x,
+    uo_h(
+        hash_len_16_mul(v.first.wrapping_add(x), w.first ^ y, mul)
+            .wrapping_add(z)
+            .wrapping_sub(u),
+        uo_h(v.second.wrapping_add(y), w.second.wrapping_add(z), K2, 30) ^ x,
         K2,
-        31);
+        31,
+    )
 }
 
 pub fn uo_hash64_with_seed(s: &[u8], seed: u64) -> u64 {
     if s.len() <= 64 {
-        return na_hash64_with_seed(s, seed)
+        return na_hash64_with_seed(s, seed);
     }
-    return uo_hash64_with_seeds(s, 0, seed)
+    uo_hash64_with_seeds(s, 0, seed)
 }
 
 pub fn uo_hash64(s: &[u8]) -> u64 {
     if s.len() <= 64 {
-        return na_hash64(s)
+        return na_hash64(s);
     }
-    return uo_hash64_with_seeds(s, 81, 0)
+    uo_hash64_with_seeds(s, 81, 0)
 }

--- a/src/farmhashxo.rs
+++ b/src/farmhashxo.rs
@@ -1,14 +1,17 @@
-use platform::*;
-use farmhashna::*;
-use farmhashuo::*;
-use farmhashna_shared::*;
+use crate::farmhashna::*;
+use crate::farmhashna_shared::*;
+use crate::farmhashuo::*;
+use crate::platform::*;
 
 fn xo_h32(s: &[u8], len: usize, mul: u64, seed0: u64, seed1: u64) -> u64 {
     let mut a = fetch64(s).wrapping_mul(K1);
     let mut b = fetch64(&s[8..]);
     let c = fetch64(&s[len - 8..]).wrapping_mul(mul);
-    let d = fetch64(&s[len - 16 ..]).wrapping_mul(K2);
-    let u = rotate64(a.wrapping_add(b), 43) .wrapping_add(rotate64(c, 30)) .wrapping_add(d) .wrapping_add(seed0);
+    let d = fetch64(&s[len - 16..]).wrapping_mul(K2);
+    let u = rotate64(a.wrapping_add(b), 43)
+        .wrapping_add(rotate64(c, 30))
+        .wrapping_add(d)
+        .wrapping_add(seed0);
     let v = a.wrapping_add(rotate64(b.wrapping_add(K2), 18).wrapping_add(c).wrapping_add(seed1));
     a = shift_mix((u ^ v).wrapping_mul(mul));
     b = shift_mix((v ^ a).wrapping_mul(mul));
@@ -34,18 +37,16 @@ fn xo_hash_len_65_to_96(s: &[u8], len: usize) -> u64 {
     let h1 = xo_h32(&s[32..], 32, mul1, 0, 0);
     let h2 = xo_h32(&s[s.len() - 32..], 32, mul1, h0, h1);
 
-    (h2 .wrapping_mul(9)
-        .wrapping_add(h0 >> 17)
-        .wrapping_add(h1 >> 21)).wrapping_mul(mul1)
+    (h2.wrapping_mul(9).wrapping_add(h0 >> 17).wrapping_add(h1 >> 21)).wrapping_mul(mul1)
 }
 
 pub fn xo_hash64(s: &[u8]) -> u64 {
     match s.len() {
-        0 ...16  => hash_len_0_to_16(s),
-        17...32  => hash_len_17_to_32(s),
-        33...64  => xo_hash_len_33_to_64(s, s.len()),
-        65...96  => xo_hash_len_65_to_96(s, s.len()),
-        97...256 => na_hash64(s),
+        0..=16 => hash_len_0_to_16(s),
+        17..=32 => hash_len_17_to_32(s),
+        33..=64 => xo_hash_len_33_to_64(s, s.len()),
+        65..=96 => xo_hash_len_65_to_96(s, s.len()),
+        97..=256 => na_hash64(s),
         _ => uo_hash64(s),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,15 @@
-mod platform;
-mod farmhashna;
+mod farmhashcc_shared;
 mod farmhashmk;
+mod farmhashmk_shared;
+mod farmhashna;
+mod farmhashna_shared;
 mod farmhashuo;
 mod farmhashxo;
-mod farmhashna_shared;
-mod farmhashcc_shared;
-mod farmhashmk_shared;
+mod platform;
 
-use farmhashna::na_hash64;
 use farmhashmk::mk_hash32;
 use farmhashmk::mk_hash32_with_seed;
+use farmhashna::na_hash64;
 use farmhashxo::xo_hash64;
 use farmhashxo::xo_hash64_with_seed;
 use farmhashxo::xo_hash64_with_seeds;
@@ -90,12 +90,16 @@ pub fn fingerprint64(s: &[u8]) -> u64 {
 }
 
 pub struct FarmHasher {
-    bytes: Vec<u8>
+    bytes: Vec<u8>,
 }
 
 impl Default for FarmHasher {
     #[inline]
-    fn default() -> FarmHasher { FarmHasher{bytes: Vec::with_capacity(20)} }
+    fn default() -> FarmHasher {
+        FarmHasher {
+            bytes: Vec::with_capacity(20),
+        }
+    }
 }
 
 impl Hasher for FarmHasher {

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -35,7 +35,7 @@ pub fn rotate32(val: u32, shift: u32) -> u32 {
     if shift == 0 {
         return val;
     }
-    return val >> shift | val << (32 - shift)
+    val >> shift | val << (32 - shift)
 }
 
 // rotate64 is a bitwise rotate
@@ -43,9 +43,8 @@ pub fn rotate64(val: u64, shift: u64) -> u64 {
     if shift == 0 {
         return val;
     }
-    return val >> shift | val << (64 - shift)
+    val >> shift | val << (64 - shift)
 }
-
 
 // Some primes between 2^63 and 2^64 for various uses.
 pub const K0: u64 = 0xc3a5c85c97cb3127;
@@ -63,7 +62,7 @@ pub fn fmix(mut h: u32) -> u32 {
     h ^= h >> 13;
     h = h.wrapping_mul(0xc2b2ae35);
     h ^= h >> 16;
-    return h;
+    h
 }
 
 // Mur is a helper from Murmur3 for combining two 32-bit values.
@@ -73,12 +72,12 @@ pub fn mur(mut a: u32, mut h: u32) -> u32 {
     a = a.wrapping_mul(C2);
     h ^= a;
     h = rotate32(h, 19);
-    return h.wrapping_mul(5).wrapping_add(0xe6546b64);
+    h.wrapping_mul(5).wrapping_add(0xe6546b64)
 }
 
+#[inline]
 pub fn bswap32(x: u32) -> u32 {
-    return ((x >> 24) & 0xFF) | ((x >> 8) & 0xFF00) |
-        ((x << 8) & 0xFF0000) | ((x << 24) & 0xFF000000)
+    ((x >> 24) & 0xFF) | ((x >> 8) & 0xFF00) | ((x << 8) & 0xFF0000) | ((x << 24) & 0xFF000000)
 }
 
 pub struct Uint128 {
@@ -95,22 +94,20 @@ pub fn hash128to64(x: Uint128) -> u64 {
     let mut b = (x.second ^ a).wrapping_mul(KMUL);
     b ^= b >> 47;
     b = b.wrapping_mul(KMUL);
-    return b;
+    b
 }
-
 
 #[cfg(test)]
 struct NumIn2Out {
     in1: u32,
     in2: u32,
-    out: u32
+    out: u32,
 }
-
 
 #[cfg(test)]
 struct NumInOut {
     in1: u32,
-    out: u32
+    out: u32,
 }
 
 #[test]
@@ -126,239 +123,1135 @@ fn test_bswap32() {
 }
 #[test]
 fn test_hash128to64() {
-    let j = hash128to64(Uint128{first:12, second:1});
+    let j = hash128to64(Uint128 { first: 12, second: 1 });
     assert_eq!(j, 463069014307918310);
 }
 
 #[test]
 fn test_rotate64() {
     let rots = vec![
-        NumIn2Out{in1: 0, in2: 0, out: 0},
+        NumIn2Out { in1: 0, in2: 0, out: 0 },
         // Rotate32
-        NumIn2Out{in1: 100, in2: 0, out: 100},
-        NumIn2Out{in1: 100, in2: 1, out: 50},
-        NumIn2Out{in1: 100, in2: 2, out: 25},
-        NumIn2Out{in1: 100, in2: 3, out: 2147483660},
-        NumIn2Out{in1: 100, in2: 4, out: 1073741830},
-        NumIn2Out{in1: 100, in2: 5, out: 536870915},
-        NumIn2Out{in1: 100, in2: 6, out: 2415919105},
-        NumIn2Out{in1: 100, in2: 7, out: 3355443200},
-        NumIn2Out{in1: 100, in2: 8, out: 1677721600},
-        NumIn2Out{in1: 100, in2: 9, out: 838860800},
-        NumIn2Out{in1: 100, in2: 10, out: 419430400},
-        NumIn2Out{in1: 100, in2: 11, out: 209715200},
-        NumIn2Out{in1: 100, in2: 12, out: 104857600},
-        NumIn2Out{in1: 100, in2: 13, out: 52428800},
-        NumIn2Out{in1: 100, in2: 14, out: 26214400},
-        NumIn2Out{in1: 100, in2: 15, out: 13107200},
-        NumIn2Out{in1: 100, in2: 16, out: 6553600},
-        NumIn2Out{in1: 100, in2: 17, out: 3276800},
-        NumIn2Out{in1: 100, in2: 18, out: 1638400},
-        NumIn2Out{in1: 100, in2: 19, out: 819200},
-        NumIn2Out{in1: 100, in2: 20, out: 409600},
-        NumIn2Out{in1: 100, in2: 21, out: 204800},
-        NumIn2Out{in1: 100, in2: 22, out: 102400},
-        NumIn2Out{in1: 100, in2: 23, out: 51200},
-        NumIn2Out{in1: 100, in2: 24, out: 25600},
-        NumIn2Out{in1: 100, in2: 25, out: 12800},
-        NumIn2Out{in1: 100, in2: 26, out: 6400},
-        NumIn2Out{in1: 100, in2: 27, out: 3200},
-        NumIn2Out{in1: 100, in2: 28, out: 1600},
-        NumIn2Out{in1: 100, in2: 29, out: 800},
-        NumIn2Out{in1: 100, in2: 30, out: 400},
-        NumIn2Out{in1: 100, in2: 31, out: 200},
-        NumIn2Out{in1: 1000, in2: 0, out: 1000},
-        NumIn2Out{in1: 1000, in2: 1, out: 500},
-        NumIn2Out{in1: 1000, in2: 2, out: 250},
-        NumIn2Out{in1: 1000, in2: 3, out: 125},
-        NumIn2Out{in1: 1000, in2: 4, out: 2147483710},
-        NumIn2Out{in1: 1000, in2: 5, out: 1073741855},
-        NumIn2Out{in1: 1000, in2: 6, out: 2684354575},
-        NumIn2Out{in1: 1000, in2: 7, out: 3489660935},
-        NumIn2Out{in1: 1000, in2: 8, out: 3892314115},
-        NumIn2Out{in1: 1000, in2: 9, out: 4093640705},
-        NumIn2Out{in1: 1000, in2: 10, out: 4194304000},
-        NumIn2Out{in1: 1000, in2: 11, out: 2097152000},
-        NumIn2Out{in1: 1000, in2: 12, out: 1048576000},
-        NumIn2Out{in1: 1000, in2: 13, out: 524288000},
-        NumIn2Out{in1: 1000, in2: 14, out: 262144000},
-        NumIn2Out{in1: 1000, in2: 15, out: 131072000},
-        NumIn2Out{in1: 1000, in2: 16, out: 65536000},
-        NumIn2Out{in1: 1000, in2: 17, out: 32768000},
-        NumIn2Out{in1: 1000, in2: 18, out: 16384000},
-        NumIn2Out{in1: 1000, in2: 19, out: 8192000},
-        NumIn2Out{in1: 1000, in2: 20, out: 4096000},
-        NumIn2Out{in1: 1000, in2: 21, out: 2048000},
-        NumIn2Out{in1: 1000, in2: 22, out: 1024000},
-        NumIn2Out{in1: 1000, in2: 23, out: 512000},
-        NumIn2Out{in1: 1000, in2: 24, out: 256000},
-        NumIn2Out{in1: 1000, in2: 25, out: 128000},
-        NumIn2Out{in1: 1000, in2: 26, out: 64000},
-        NumIn2Out{in1: 1000, in2: 27, out: 32000},
-        NumIn2Out{in1: 1000, in2: 28, out: 16000},
-        NumIn2Out{in1: 1000, in2: 29, out: 8000},
-        NumIn2Out{in1: 1000, in2: 30, out: 4000},
-        NumIn2Out{in1: 1000, in2: 31, out: 2000},
-        NumIn2Out{in1: 100000, in2: 0, out: 100000},
-        NumIn2Out{in1: 100000, in2: 1, out: 50000},
-        NumIn2Out{in1: 100000, in2: 2, out: 25000},
-        NumIn2Out{in1: 100000, in2: 3, out: 12500},
-        NumIn2Out{in1: 100000, in2: 4, out: 6250},
-        NumIn2Out{in1: 100000, in2: 5, out: 3125},
-        NumIn2Out{in1: 100000, in2: 6, out: 2147485210},
-        NumIn2Out{in1: 100000, in2: 7, out: 1073742605},
-        NumIn2Out{in1: 100000, in2: 8, out: 2684354950},
-        NumIn2Out{in1: 100000, in2: 9, out: 1342177475},
-        NumIn2Out{in1: 100000, in2: 10, out: 2818572385},
-        NumIn2Out{in1: 100000, in2: 11, out: 3556769840},
-        NumIn2Out{in1: 100000, in2: 12, out: 1778384920},
-        NumIn2Out{in1: 100000, in2: 13, out: 889192460},
-        NumIn2Out{in1: 100000, in2: 14, out: 444596230},
-        NumIn2Out{in1: 100000, in2: 15, out: 222298115},
-        NumIn2Out{in1: 100000, in2: 16, out: 2258632705},
-        NumIn2Out{in1: 100000, in2: 17, out: 3276800000},
-        NumIn2Out{in1: 100000, in2: 18, out: 1638400000},
-        NumIn2Out{in1: 100000, in2: 19, out: 819200000},
-        NumIn2Out{in1: 100000, in2: 20, out: 409600000},
-        NumIn2Out{in1: 100000, in2: 21, out: 204800000},
-        NumIn2Out{in1: 100000, in2: 22, out: 102400000},
-        NumIn2Out{in1: 100000, in2: 23, out: 51200000},
-        NumIn2Out{in1: 100000, in2: 24, out: 25600000},
-        NumIn2Out{in1: 100000, in2: 25, out: 12800000},
-        NumIn2Out{in1: 100000, in2: 26, out: 6400000},
-        NumIn2Out{in1: 100000, in2: 27, out: 3200000},
-        NumIn2Out{in1: 100000, in2: 28, out: 1600000},
-        NumIn2Out{in1: 100000, in2: 29, out: 800000},
-        NumIn2Out{in1: 100000, in2: 30, out: 400000},
-        NumIn2Out{in1: 100000, in2: 31, out: 200000},
-        NumIn2Out{in1: 1000000, in2: 0, out: 1000000},
-        NumIn2Out{in1: 1000000, in2: 1, out: 500000},
-        NumIn2Out{in1: 1000000, in2: 2, out: 250000},
-        NumIn2Out{in1: 1000000, in2: 3, out: 125000},
-        NumIn2Out{in1: 1000000, in2: 4, out: 62500},
-        NumIn2Out{in1: 1000000, in2: 5, out: 31250},
-        NumIn2Out{in1: 1000000, in2: 6, out: 15625},
-        NumIn2Out{in1: 1000000, in2: 7, out: 2147491460},
-        NumIn2Out{in1: 1000000, in2: 8, out: 1073745730},
-        NumIn2Out{in1: 1000000, in2: 9, out: 536872865},
-        NumIn2Out{in1: 1000000, in2: 10, out: 2415920080},
-        NumIn2Out{in1: 1000000, in2: 11, out: 1207960040},
-        NumIn2Out{in1: 1000000, in2: 12, out: 603980020},
-        NumIn2Out{in1: 1000000, in2: 13, out: 301990010},
-        NumIn2Out{in1: 1000000, in2: 14, out: 150995005},
-        NumIn2Out{in1: 1000000, in2: 15, out: 2222981150},
-        NumIn2Out{in1: 1000000, in2: 16, out: 1111490575},
-        NumIn2Out{in1: 1000000, in2: 17, out: 2703228935},
-        NumIn2Out{in1: 1000000, in2: 18, out: 3499098115},
-        NumIn2Out{in1: 1000000, in2: 19, out: 3897032705},
-        NumIn2Out{in1: 1000000, in2: 20, out: 4096000000},
-        NumIn2Out{in1: 1000000, in2: 21, out: 2048000000},
-        NumIn2Out{in1: 1000000, in2: 22, out: 1024000000},
-        NumIn2Out{in1: 1000000, in2: 23, out: 512000000},
-        NumIn2Out{in1: 1000000, in2: 24, out: 256000000},
-        NumIn2Out{in1: 1000000, in2: 25, out: 128000000},
-        NumIn2Out{in1: 1000000, in2: 26, out: 64000000},
-        NumIn2Out{in1: 1000000, in2: 27, out: 32000000},
-        NumIn2Out{in1: 1000000, in2: 28, out: 16000000},
-        NumIn2Out{in1: 1000000, in2: 29, out: 8000000},
-        NumIn2Out{in1: 1000000, in2: 30, out: 4000000},
-        NumIn2Out{in1: 1000000, in2: 31, out: 2000000},
-        NumIn2Out{in1: 10000000, in2: 0, out: 10000000},
-        NumIn2Out{in1: 10000000, in2: 1, out: 5000000},
-        NumIn2Out{in1: 10000000, in2: 2, out: 2500000},
-        NumIn2Out{in1: 10000000, in2: 3, out: 1250000},
-        NumIn2Out{in1: 10000000, in2: 4, out: 625000},
-        NumIn2Out{in1: 10000000, in2: 5, out: 312500},
-        NumIn2Out{in1: 10000000, in2: 6, out: 156250},
-        NumIn2Out{in1: 10000000, in2: 7, out: 78125},
-        NumIn2Out{in1: 10000000, in2: 8, out: 2147522710},
-        NumIn2Out{in1: 10000000, in2: 9, out: 1073761355},
-        NumIn2Out{in1: 10000000, in2: 10, out: 2684364325},
-        NumIn2Out{in1: 10000000, in2: 11, out: 3489665810},
-        NumIn2Out{in1: 10000000, in2: 12, out: 1744832905},
-        NumIn2Out{in1: 10000000, in2: 13, out: 3019900100},
-        NumIn2Out{in1: 10000000, in2: 14, out: 1509950050},
-        NumIn2Out{in1: 10000000, in2: 15, out: 754975025},
-        NumIn2Out{in1: 10000000, in2: 16, out: 2524971160},
-        NumIn2Out{in1: 10000000, in2: 17, out: 1262485580},
-        NumIn2Out{in1: 10000000, in2: 18, out: 631242790},
-        NumIn2Out{in1: 10000000, in2: 19, out: 315621395},
-        NumIn2Out{in1: 10000000, in2: 20, out: 2305294345},
-        NumIn2Out{in1: 10000000, in2: 21, out: 3300130820},
-        NumIn2Out{in1: 10000000, in2: 22, out: 1650065410},
-        NumIn2Out{in1: 10000000, in2: 23, out: 825032705},
-        NumIn2Out{in1: 10000000, in2: 24, out: 2560000000},
-        NumIn2Out{in1: 10000000, in2: 25, out: 1280000000},
-        NumIn2Out{in1: 10000000, in2: 26, out: 640000000},
-        NumIn2Out{in1: 10000000, in2: 27, out: 320000000},
-        NumIn2Out{in1: 10000000, in2: 28, out: 160000000},
-        NumIn2Out{in1: 10000000, in2: 29, out: 80000000},
-        NumIn2Out{in1: 10000000, in2: 30, out: 40000000},
-        NumIn2Out{in1: 10000000, in2: 31, out: 20000000},
-        NumIn2Out{in1: 100000000, in2: 0, out: 100000000},
-        NumIn2Out{in1: 100000000, in2: 1, out: 50000000},
-        NumIn2Out{in1: 100000000, in2: 2, out: 25000000},
-        NumIn2Out{in1: 100000000, in2: 3, out: 12500000},
-        NumIn2Out{in1: 100000000, in2: 4, out: 6250000},
-        NumIn2Out{in1: 100000000, in2: 5, out: 3125000},
-        NumIn2Out{in1: 100000000, in2: 6, out: 1562500},
-        NumIn2Out{in1: 100000000, in2: 7, out: 781250},
-        NumIn2Out{in1: 100000000, in2: 8, out: 390625},
-        NumIn2Out{in1: 100000000, in2: 9, out: 2147678960},
-        NumIn2Out{in1: 100000000, in2: 10, out: 1073839480},
-        NumIn2Out{in1: 100000000, in2: 11, out: 536919740},
-        NumIn2Out{in1: 100000000, in2: 12, out: 268459870},
-        NumIn2Out{in1: 100000000, in2: 13, out: 134229935},
-        NumIn2Out{in1: 100000000, in2: 14, out: 2214598615},
-        NumIn2Out{in1: 100000000, in2: 15, out: 3254782955},
-        NumIn2Out{in1: 100000000, in2: 16, out: 3774875125},
-        NumIn2Out{in1: 100000000, in2: 17, out: 4034921210},
-        NumIn2Out{in1: 100000000, in2: 18, out: 2017460605},
-        NumIn2Out{in1: 100000000, in2: 19, out: 3156213950},
-        NumIn2Out{in1: 100000000, in2: 20, out: 1578106975},
-        NumIn2Out{in1: 100000000, in2: 21, out: 2936537135},
-        NumIn2Out{in1: 100000000, in2: 22, out: 3615752215},
-        NumIn2Out{in1: 100000000, in2: 23, out: 3955359755},
-        NumIn2Out{in1: 100000000, in2: 24, out: 4125163525},
-        NumIn2Out{in1: 100000000, in2: 25, out: 4210065410},
-        NumIn2Out{in1: 100000000, in2: 26, out: 2105032705},
-        NumIn2Out{in1: 100000000, in2: 27, out: 3200000000},
-        NumIn2Out{in1: 100000000, in2: 28, out: 1600000000},
-        NumIn2Out{in1: 100000000, in2: 29, out: 800000000},
-        NumIn2Out{in1: 100000000, in2: 30, out: 400000000},
-        NumIn2Out{in1: 100000000, in2: 31, out: 200000000},
-        NumIn2Out{in1: 1000000000, in2: 0, out: 1000000000},
-        NumIn2Out{in1: 1000000000, in2: 1, out: 500000000},
-        NumIn2Out{in1: 1000000000, in2: 2, out: 250000000},
-        NumIn2Out{in1: 1000000000, in2: 3, out: 125000000},
-        NumIn2Out{in1: 1000000000, in2: 4, out: 62500000},
-        NumIn2Out{in1: 1000000000, in2: 5, out: 31250000},
-        NumIn2Out{in1: 1000000000, in2: 6, out: 15625000},
-        NumIn2Out{in1: 1000000000, in2: 7, out: 7812500},
-        NumIn2Out{in1: 1000000000, in2: 8, out: 3906250},
-        NumIn2Out{in1: 1000000000, in2: 9, out: 1953125},
-        NumIn2Out{in1: 1000000000, in2: 10, out: 2148460210},
-        NumIn2Out{in1: 1000000000, in2: 11, out: 1074230105},
-        NumIn2Out{in1: 1000000000, in2: 12, out: 2684598700},
-        NumIn2Out{in1: 1000000000, in2: 13, out: 1342299350},
-        NumIn2Out{in1: 1000000000, in2: 14, out: 671149675},
-        NumIn2Out{in1: 1000000000, in2: 15, out: 2483058485},
-        NumIn2Out{in1: 1000000000, in2: 16, out: 3389012890},
-        NumIn2Out{in1: 1000000000, in2: 17, out: 1694506445},
-        NumIn2Out{in1: 1000000000, in2: 18, out: 2994736870},
-        NumIn2Out{in1: 1000000000, in2: 19, out: 1497368435},
-        NumIn2Out{in1: 1000000000, in2: 20, out: 2896167865},
-        NumIn2Out{in1: 1000000000, in2: 21, out: 3595567580},
-        NumIn2Out{in1: 1000000000, in2: 22, out: 1797783790},
-        NumIn2Out{in1: 1000000000, in2: 23, out: 898891895},
-        NumIn2Out{in1: 1000000000, in2: 24, out: 2596929595},
-        NumIn2Out{in1: 1000000000, in2: 25, out: 3445948445},
-        NumIn2Out{in1: 1000000000, in2: 26, out: 3870457870},
-        NumIn2Out{in1: 1000000000, in2: 27, out: 1935228935},
-        NumIn2Out{in1: 1000000000, in2: 28, out: 3115098115},
-        NumIn2Out{in1: 1000000000, in2: 29, out: 3705032705},
-        NumIn2Out{in1: 1000000000, in2: 30, out: 4000000000},
-        NumIn2Out{in1: 1000000000, in2: 31, out: 2000000000}
+        NumIn2Out {
+            in1: 100,
+            in2: 0,
+            out: 100,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 1,
+            out: 50,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 2,
+            out: 25,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 3,
+            out: 2147483660,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 4,
+            out: 1073741830,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 5,
+            out: 536870915,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 6,
+            out: 2415919105,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 7,
+            out: 3355443200,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 8,
+            out: 1677721600,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 9,
+            out: 838860800,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 10,
+            out: 419430400,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 11,
+            out: 209715200,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 12,
+            out: 104857600,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 13,
+            out: 52428800,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 14,
+            out: 26214400,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 15,
+            out: 13107200,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 16,
+            out: 6553600,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 17,
+            out: 3276800,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 18,
+            out: 1638400,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 19,
+            out: 819200,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 20,
+            out: 409600,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 21,
+            out: 204800,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 22,
+            out: 102400,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 23,
+            out: 51200,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 24,
+            out: 25600,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 25,
+            out: 12800,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 26,
+            out: 6400,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 27,
+            out: 3200,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 28,
+            out: 1600,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 29,
+            out: 800,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 30,
+            out: 400,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 31,
+            out: 200,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 0,
+            out: 1000,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 1,
+            out: 500,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 2,
+            out: 250,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 3,
+            out: 125,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 4,
+            out: 2147483710,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 5,
+            out: 1073741855,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 6,
+            out: 2684354575,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 7,
+            out: 3489660935,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 8,
+            out: 3892314115,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 9,
+            out: 4093640705,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 10,
+            out: 4194304000,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 11,
+            out: 2097152000,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 12,
+            out: 1048576000,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 13,
+            out: 524288000,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 14,
+            out: 262144000,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 15,
+            out: 131072000,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 16,
+            out: 65536000,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 17,
+            out: 32768000,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 18,
+            out: 16384000,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 19,
+            out: 8192000,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 20,
+            out: 4096000,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 21,
+            out: 2048000,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 22,
+            out: 1024000,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 23,
+            out: 512000,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 24,
+            out: 256000,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 25,
+            out: 128000,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 26,
+            out: 64000,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 27,
+            out: 32000,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 28,
+            out: 16000,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 29,
+            out: 8000,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 30,
+            out: 4000,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 31,
+            out: 2000,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 0,
+            out: 100000,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 1,
+            out: 50000,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 2,
+            out: 25000,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 3,
+            out: 12500,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 4,
+            out: 6250,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 5,
+            out: 3125,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 6,
+            out: 2147485210,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 7,
+            out: 1073742605,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 8,
+            out: 2684354950,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 9,
+            out: 1342177475,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 10,
+            out: 2818572385,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 11,
+            out: 3556769840,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 12,
+            out: 1778384920,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 13,
+            out: 889192460,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 14,
+            out: 444596230,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 15,
+            out: 222298115,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 16,
+            out: 2258632705,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 17,
+            out: 3276800000,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 18,
+            out: 1638400000,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 19,
+            out: 819200000,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 20,
+            out: 409600000,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 21,
+            out: 204800000,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 22,
+            out: 102400000,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 23,
+            out: 51200000,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 24,
+            out: 25600000,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 25,
+            out: 12800000,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 26,
+            out: 6400000,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 27,
+            out: 3200000,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 28,
+            out: 1600000,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 29,
+            out: 800000,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 30,
+            out: 400000,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 31,
+            out: 200000,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 0,
+            out: 1000000,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 1,
+            out: 500000,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 2,
+            out: 250000,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 3,
+            out: 125000,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 4,
+            out: 62500,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 5,
+            out: 31250,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 6,
+            out: 15625,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 7,
+            out: 2147491460,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 8,
+            out: 1073745730,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 9,
+            out: 536872865,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 10,
+            out: 2415920080,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 11,
+            out: 1207960040,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 12,
+            out: 603980020,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 13,
+            out: 301990010,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 14,
+            out: 150995005,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 15,
+            out: 2222981150,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 16,
+            out: 1111490575,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 17,
+            out: 2703228935,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 18,
+            out: 3499098115,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 19,
+            out: 3897032705,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 20,
+            out: 4096000000,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 21,
+            out: 2048000000,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 22,
+            out: 1024000000,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 23,
+            out: 512000000,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 24,
+            out: 256000000,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 25,
+            out: 128000000,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 26,
+            out: 64000000,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 27,
+            out: 32000000,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 28,
+            out: 16000000,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 29,
+            out: 8000000,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 30,
+            out: 4000000,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 31,
+            out: 2000000,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 0,
+            out: 10000000,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 1,
+            out: 5000000,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 2,
+            out: 2500000,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 3,
+            out: 1250000,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 4,
+            out: 625000,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 5,
+            out: 312500,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 6,
+            out: 156250,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 7,
+            out: 78125,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 8,
+            out: 2147522710,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 9,
+            out: 1073761355,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 10,
+            out: 2684364325,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 11,
+            out: 3489665810,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 12,
+            out: 1744832905,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 13,
+            out: 3019900100,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 14,
+            out: 1509950050,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 15,
+            out: 754975025,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 16,
+            out: 2524971160,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 17,
+            out: 1262485580,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 18,
+            out: 631242790,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 19,
+            out: 315621395,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 20,
+            out: 2305294345,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 21,
+            out: 3300130820,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 22,
+            out: 1650065410,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 23,
+            out: 825032705,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 24,
+            out: 2560000000,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 25,
+            out: 1280000000,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 26,
+            out: 640000000,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 27,
+            out: 320000000,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 28,
+            out: 160000000,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 29,
+            out: 80000000,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 30,
+            out: 40000000,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 31,
+            out: 20000000,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 0,
+            out: 100000000,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 1,
+            out: 50000000,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 2,
+            out: 25000000,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 3,
+            out: 12500000,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 4,
+            out: 6250000,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 5,
+            out: 3125000,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 6,
+            out: 1562500,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 7,
+            out: 781250,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 8,
+            out: 390625,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 9,
+            out: 2147678960,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 10,
+            out: 1073839480,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 11,
+            out: 536919740,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 12,
+            out: 268459870,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 13,
+            out: 134229935,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 14,
+            out: 2214598615,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 15,
+            out: 3254782955,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 16,
+            out: 3774875125,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 17,
+            out: 4034921210,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 18,
+            out: 2017460605,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 19,
+            out: 3156213950,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 20,
+            out: 1578106975,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 21,
+            out: 2936537135,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 22,
+            out: 3615752215,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 23,
+            out: 3955359755,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 24,
+            out: 4125163525,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 25,
+            out: 4210065410,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 26,
+            out: 2105032705,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 27,
+            out: 3200000000,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 28,
+            out: 1600000000,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 29,
+            out: 800000000,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 30,
+            out: 400000000,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 31,
+            out: 200000000,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 0,
+            out: 1000000000,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 1,
+            out: 500000000,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 2,
+            out: 250000000,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 3,
+            out: 125000000,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 4,
+            out: 62500000,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 5,
+            out: 31250000,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 6,
+            out: 15625000,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 7,
+            out: 7812500,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 8,
+            out: 3906250,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 9,
+            out: 1953125,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 10,
+            out: 2148460210,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 11,
+            out: 1074230105,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 12,
+            out: 2684598700,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 13,
+            out: 1342299350,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 14,
+            out: 671149675,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 15,
+            out: 2483058485,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 16,
+            out: 3389012890,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 17,
+            out: 1694506445,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 18,
+            out: 2994736870,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 19,
+            out: 1497368435,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 20,
+            out: 2896167865,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 21,
+            out: 3595567580,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 22,
+            out: 1797783790,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 23,
+            out: 898891895,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 24,
+            out: 2596929595,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 25,
+            out: 3445948445,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 26,
+            out: 3870457870,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 27,
+            out: 1935228935,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 28,
+            out: 3115098115,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 29,
+            out: 3705032705,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 30,
+            out: 4000000000,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 31,
+            out: 2000000000,
+        },
     ];
     for f in rots {
         let u = rotate32(f.in1 as u32, f.in2 as u32);
@@ -370,55 +1263,251 @@ fn test_rotate64() {
 fn test_mux() {
     let murs = vec![
         // Mur
-        NumIn2Out{in1: 100, in2: 100, out: 296331858},
-        NumIn2Out{in1: 100, in2: 1000, out: 322382418},
-        NumIn2Out{in1: 100, in2: 100000, out: 3309578834},
-        NumIn2Out{in1: 100, in2: 1000000, out: 2332043863},
-        NumIn2Out{in1: 100, in2: 10000000, out: 1532504573},
-        NumIn2Out{in1: 100, in2: 100000000, out: 109586476},
-        NumIn2Out{in1: 100, in2: 1000000000, out: 4129826525},
-        NumIn2Out{in1: 1000, in2: 100, out: 904209336},
-        NumIn2Out{in1: 1000, in2: 1000, out: 909616056},
-        NumIn2Out{in1: 1000, in2: 100000, out: 2222629816},
-        NumIn2Out{in1: 1000, in2: 1000000, out: 4010714045},
-        NumIn2Out{in1: 1000, in2: 10000000, out: 3999704087},
-        NumIn2Out{in1: 1000, in2: 100000000, out: 3377899334},
-        NumIn2Out{in1: 1000, in2: 1000000000, out: 2218174583},
-        NumIn2Out{in1: 100000, in2: 100, out: 193992030},
-        NumIn2Out{in1: 100000, in2: 1000, out: 157783390},
-        NumIn2Out{in1: 100000, in2: 100000, out: 4239037790},
-        NumIn2Out{in1: 100000, in2: 1000000, out: 2456196451},
-        NumIn2Out{in1: 100000, in2: 10000000, out: 1388221705},
-        NumIn2Out{in1: 100000, in2: 100000000, out: 2402195232},
-        NumIn2Out{in1: 100000, in2: 1000000000, out: 3180234409},
-        NumIn2Out{in1: 1000000, in2: 100, out: 3909538526},
-        NumIn2Out{in1: 1000000, in2: 1000, out: 3946730206},
-        NumIn2Out{in1: 1000000, in2: 100000, out: 3622916830},
-        NumIn2Out{in1: 1000000, in2: 1000000, out: 1918718691},
-        NumIn2Out{in1: 1000000, in2: 10000000, out: 1107645065},
-        NumIn2Out{in1: 1000000, in2: 100000000, out: 2509590432},
-        NumIn2Out{in1: 1000000, in2: 1000000000, out: 2805288489},
-        NumIn2Out{in1: 10000000, in2: 100, out: 1497840043},
-        NumIn2Out{in1: 10000000, in2: 1000, out: 1471134123},
-        NumIn2Out{in1: 10000000, in2: 100000, out: 1794947499},
-        NumIn2Out{in1: 10000000, in2: 1000000, out: 3491281318},
-        NumIn2Out{in1: 10000000, in2: 10000000, out: 353417548},
-        NumIn2Out{in1: 10000000, in2: 100000000, out: 2900408157},
-        NumIn2Out{in1: 10000000, in2: 1000000000, out: 2604713900},
-        NumIn2Out{in1: 100000000, in2: 100, out: 3858265169},
-        NumIn2Out{in1: 100000000, in2: 1000, out: 3843028049},
-        NumIn2Out{in1: 100000000, in2: 100000, out: 2534601809},
-        NumIn2Out{in1: 100000000, in2: 1000000, out: 2896622668},
-        NumIn2Out{in1: 100000000, in2: 10000000, out: 754906278},
-        NumIn2Out{in1: 100000000, in2: 100000000, out: 716108471},
-        NumIn2Out{in1: 100000000, in2: 1000000000, out: 567217414},
-        NumIn2Out{in1: 1000000000, in2: 100, out: 4215452687},
-        NumIn2Out{in1: 1000000000, in2: 1000, out: 4179244047},
-        NumIn2Out{in1: 1000000000, in2: 100000, out: 1192047631},
-        NumIn2Out{in1: 1000000000, in2: 1000000, out: 32584714},
-        NumIn2Out{in1: 1000000000, in2: 10000000, out: 2969121872},
-        NumIn2Out{in1: 1000000000, in2: 100000000, out: 107557113},
-        NumIn2Out{in1: 1000000000, in2: 1000000000, out: 2529766768}
+        NumIn2Out {
+            in1: 100,
+            in2: 100,
+            out: 296331858,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 1000,
+            out: 322382418,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 100000,
+            out: 3309578834,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 1000000,
+            out: 2332043863,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 10000000,
+            out: 1532504573,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 100000000,
+            out: 109586476,
+        },
+        NumIn2Out {
+            in1: 100,
+            in2: 1000000000,
+            out: 4129826525,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 100,
+            out: 904209336,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 1000,
+            out: 909616056,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 100000,
+            out: 2222629816,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 1000000,
+            out: 4010714045,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 10000000,
+            out: 3999704087,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 100000000,
+            out: 3377899334,
+        },
+        NumIn2Out {
+            in1: 1000,
+            in2: 1000000000,
+            out: 2218174583,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 100,
+            out: 193992030,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 1000,
+            out: 157783390,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 100000,
+            out: 4239037790,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 1000000,
+            out: 2456196451,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 10000000,
+            out: 1388221705,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 100000000,
+            out: 2402195232,
+        },
+        NumIn2Out {
+            in1: 100000,
+            in2: 1000000000,
+            out: 3180234409,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 100,
+            out: 3909538526,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 1000,
+            out: 3946730206,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 100000,
+            out: 3622916830,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 1000000,
+            out: 1918718691,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 10000000,
+            out: 1107645065,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 100000000,
+            out: 2509590432,
+        },
+        NumIn2Out {
+            in1: 1000000,
+            in2: 1000000000,
+            out: 2805288489,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 100,
+            out: 1497840043,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 1000,
+            out: 1471134123,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 100000,
+            out: 1794947499,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 1000000,
+            out: 3491281318,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 10000000,
+            out: 353417548,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 100000000,
+            out: 2900408157,
+        },
+        NumIn2Out {
+            in1: 10000000,
+            in2: 1000000000,
+            out: 2604713900,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 100,
+            out: 3858265169,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 1000,
+            out: 3843028049,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 100000,
+            out: 2534601809,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 1000000,
+            out: 2896622668,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 10000000,
+            out: 754906278,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 100000000,
+            out: 716108471,
+        },
+        NumIn2Out {
+            in1: 100000000,
+            in2: 1000000000,
+            out: 567217414,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 100,
+            out: 4215452687,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 1000,
+            out: 4179244047,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 100000,
+            out: 1192047631,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 1000000,
+            out: 32584714,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 10000000,
+            out: 2969121872,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 100000000,
+            out: 107557113,
+        },
+        NumIn2Out {
+            in1: 1000000000,
+            in2: 1000000000,
+            out: 2529766768,
+        },
     ];
     for m in murs {
         let u = mur(m.in1 as u32, m.in2 as u32);
@@ -429,14 +1518,35 @@ fn test_mux() {
 #[test]
 fn test_fmix() {
     let fmix_in_out = vec![
-        NumInOut{in1: 0, out: 0},
-        NumInOut{in1: 100, out: 4258159850},
-        NumInOut{in1: 1000, out: 1718167128},
-        NumInOut{in1: 100000, out: 1391155934},
-        NumInOut{in1: 1000000, out: 37787785},
-        NumInOut{in1: 10000000, out: 3568206535},
-        NumInOut{in1: 100000000, out: 701900797},
-        NumInOut{in1: 1000000000, out: 4234498180}
+        NumInOut { in1: 0, out: 0 },
+        NumInOut {
+            in1: 100,
+            out: 4258159850,
+        },
+        NumInOut {
+            in1: 1000,
+            out: 1718167128,
+        },
+        NumInOut {
+            in1: 100000,
+            out: 1391155934,
+        },
+        NumInOut {
+            in1: 1000000,
+            out: 37787785,
+        },
+        NumInOut {
+            in1: 10000000,
+            out: 3568206535,
+        },
+        NumInOut {
+            in1: 100000000,
+            out: 701900797,
+        },
+        NumInOut {
+            in1: 1000000000,
+            out: 4234498180,
+        },
     ];
 
     for f in fmix_in_out {

--- a/tests/test_hash32.rs
+++ b/tests/test_hash32.rs
@@ -4,20 +4,38 @@ use self::farmhash::*;
 
 #[cfg(test)]
 struct StrToHash32<'a> {
-    value:    &'a str,
-    expected: u32
+    value: &'a str,
+    expected: u32,
 }
 
 #[test]
 fn test_hash32_len_0_to_4() {
     let str_to_hash32 = vec![
         // Hash32
-        StrToHash32{expected: 0xdc56d17a, value: ""},
-        StrToHash32{expected: 0x3c973d4d, value: "a"},
-        StrToHash32{expected: 0x417330fd, value: "ab"},
-        StrToHash32{expected: 0x2f635ec7, value: "abc"},
-        StrToHash32{expected: 0x98b51e95, value: "abcd"},
-        StrToHash32{expected: 0xf2311502, value: "hi"},
+        StrToHash32 {
+            expected: 0xdc56d17a,
+            value: "",
+        },
+        StrToHash32 {
+            expected: 0x3c973d4d,
+            value: "a",
+        },
+        StrToHash32 {
+            expected: 0x417330fd,
+            value: "ab",
+        },
+        StrToHash32 {
+            expected: 0x2f635ec7,
+            value: "abc",
+        },
+        StrToHash32 {
+            expected: 0x98b51e95,
+            value: "abcd",
+        },
+        StrToHash32 {
+            expected: 0xf2311502,
+            value: "hi",
+        },
     ];
     for s in str_to_hash32 {
         let hash = hash32((&s.value).as_bytes());
@@ -28,18 +46,38 @@ fn test_hash32_len_0_to_4() {
     }
 }
 
-
 #[test]
 fn test_hash32_len_5_to_12() {
     let str_to_hash32 = vec![
         // Hash32
-        StrToHash32{expected: 0xa3f366ac, value: "abcde"},
-        StrToHash32{expected: 0x0f813aa4, value: "abcdef"},
-        StrToHash32{expected: 0x21deb6d7, value: "abcdefg"},
-        StrToHash32{expected: 0xfd7ec8b9, value: "abcdefgh"},
-        StrToHash32{expected: 0x6f98dc86, value: "abcdefghi"},
-        StrToHash32{expected: 0xf2669361, value: "abcdefghij"},
-        StrToHash32{expected: 0x19a7581a, value: "hello world"},
+        StrToHash32 {
+            expected: 0xa3f366ac,
+            value: "abcde",
+        },
+        StrToHash32 {
+            expected: 0x0f813aa4,
+            value: "abcdef",
+        },
+        StrToHash32 {
+            expected: 0x21deb6d7,
+            value: "abcdefg",
+        },
+        StrToHash32 {
+            expected: 0xfd7ec8b9,
+            value: "abcdefgh",
+        },
+        StrToHash32 {
+            expected: 0x6f98dc86,
+            value: "abcdefghi",
+        },
+        StrToHash32 {
+            expected: 0xf2669361,
+            value: "abcdefghij",
+        },
+        StrToHash32 {
+            expected: 0x19a7581a,
+            value: "hello world",
+        },
     ];
     for s in str_to_hash32 {
         let hash = hash32((&s.value).as_bytes());
@@ -54,10 +92,22 @@ fn test_hash32_len_5_to_12() {
 fn test_hash32_len_13_to_24() {
     let str_to_hash32 = vec![
         // Hash32
-        StrToHash32{expected: 0x7acdc357, value: "fred@example.com"},
-        StrToHash32{expected: 0xaf0a30fe, value: "lee@lmmrtech.com"},
-        StrToHash32{expected: 0x5d8cdbf4, value: "docklandsman@gmail.com"},
-        StrToHash32{expected: 0xc6246b8d, value: "size:  a.out:  bad magic"},
+        StrToHash32 {
+            expected: 0x7acdc357,
+            value: "fred@example.com",
+        },
+        StrToHash32 {
+            expected: 0xaf0a30fe,
+            value: "lee@lmmrtech.com",
+        },
+        StrToHash32 {
+            expected: 0x5d8cdbf4,
+            value: "docklandsman@gmail.com",
+        },
+        StrToHash32 {
+            expected: 0xc6246b8d,
+            value: "size:  a.out:  bad magic",
+        },
     ];
     for s in str_to_hash32 {
         let hash = hash32((&s.value).as_bytes());
@@ -68,31 +118,90 @@ fn test_hash32_len_13_to_24() {
     }
 }
 
-
 #[test]
 fn test_hash32_else() {
     let str_to_hash32 = vec![
         // Hash32
-        StrToHash32{expected: 0x9c8f96f3, value: "Go is a tool for managing Go source code.Usage:	go command [arguments]The commands are:    build       compile packages and dependencies    clean       remove object files    env         print Go environment information    fix         run go tool fix on packages    fmt         run gofmt on package sources    generate    generate Go files by processing source    get         download and install packages and dependencies    install     compile and install packages and dependencies    list        list packages    run         compile and run Go program    test        test packages    tool        run specified go tool    version     print Go version    vet         run go tool vet on packagesUse go help [command] for more information about a command.Additional help topics:    c           calling between Go and C    filetype    file types    gopath      GOPATH environment variable    importpath  import path syntax    packages    description of package lists    testflag    description of testing flags    testfunc    description of testing functionsUse go help [topic] for more information about that topic."},
-        StrToHash32{expected: 0xe273108f, value: "Discard medicine more than two years old."},
-        StrToHash32{expected: 0xf585dfc4, value: "He who has a shady past knows that nice guys finish last."},
-        StrToHash32{expected: 0x363394d1, value: "I wouldn't marry him with a ten foot pole."},
-        StrToHash32{expected: 0x7613810f, value: "Free! Free!/A trip/to Mars/for 900/empty jars/Burma Shave"},
-        StrToHash32{expected: 0x2cc30bb7, value: "The days of the digital watch are numbered.  -Tom Stoppard"},
-        StrToHash32{expected: 0x322984d9, value: "Nepal premier won't resign."},
-        StrToHash32{expected: 0xa5812ac8, value: "For every action there is an equal and opposite government program."},
-        StrToHash32{expected: 0x1090d244, value: "His money is twice tainted: 'taint yours and 'taint mine."},
-        StrToHash32{expected: 0xff16c9e6, value: "There is no reason for any individual to have a computer in their home. -Ken Olsen, 1977"},
-        StrToHash32{expected: 0xcc3d0ff2, value: "It's a tiny change to the code and not completely disgusting. - Bob Manchek"},
-        StrToHash32{expected: 0xd225e92e, value: "The major problem is with sendmail.  -Mark Horton"},
-        StrToHash32{expected: 0x1b8db5d0, value: "Give me a rock, paper and scissors and I will move the world.  CCFestoon"},
-        StrToHash32{expected: 0x4fda5f07, value: "If the enemy is within range, then so are you."},
-        StrToHash32{expected: 0x2e18e880, value: "It's well we cannot hear the screams/That we create in others' dreams."},
-        StrToHash32{expected: 0xd07de88f, value: "You remind me of a TV show, but that's all right: I watch it anyway."},
-        StrToHash32{expected: 0x221694e4, value: "C is as portable as Stonehedge!!"},
-        StrToHash32{expected: 0xe2053c2c, value: "Even if I could be Shakespeare, I think I should still choose to be Faraday. - A. Huxley"},
-        StrToHash32{expected: 0x11c493bb, value: "The fugacity of a constituent in a mixture of gases at a given temperature is proportional to its mole fraction.  Lewis-Randall Rule"},
-        StrToHash32{expected: 0x0819a4e8, value: "How can you write a big system without C++?  -Paul Glick"}
+        StrToHash32 {
+            expected: 0x9c8f96f3,
+            value: "Go is a tool for managing Go source code.Usage:	go command [arguments]The commands are:    build       compile packages and dependencies    clean       remove object files    env         print Go environment information    fix         run go tool fix on packages    fmt         run gofmt on package sources    generate    generate Go files by processing source    get         download and install packages and dependencies    install     compile and install packages and dependencies    list        list packages    run         compile and run Go program    test        test packages    tool        run specified go tool    version     print Go version    vet         run go tool vet on packagesUse go help [command] for more information about a command.Additional help topics:    c           calling between Go and C    filetype    file types    gopath      GOPATH environment variable    importpath  import path syntax    packages    description of package lists    testflag    description of testing flags    testfunc    description of testing functionsUse go help [topic] for more information about that topic.",
+        },
+        StrToHash32 {
+            expected: 0xe273108f,
+            value: "Discard medicine more than two years old.",
+        },
+        StrToHash32 {
+            expected: 0xf585dfc4,
+            value: "He who has a shady past knows that nice guys finish last.",
+        },
+        StrToHash32 {
+            expected: 0x363394d1,
+            value: "I wouldn't marry him with a ten foot pole.",
+        },
+        StrToHash32 {
+            expected: 0x7613810f,
+            value: "Free! Free!/A trip/to Mars/for 900/empty jars/Burma Shave",
+        },
+        StrToHash32 {
+            expected: 0x2cc30bb7,
+            value: "The days of the digital watch are numbered.  -Tom Stoppard",
+        },
+        StrToHash32 {
+            expected: 0x322984d9,
+            value: "Nepal premier won't resign.",
+        },
+        StrToHash32 {
+            expected: 0xa5812ac8,
+            value: "For every action there is an equal and opposite government program.",
+        },
+        StrToHash32 {
+            expected: 0x1090d244,
+            value: "His money is twice tainted: 'taint yours and 'taint mine.",
+        },
+        StrToHash32 {
+            expected: 0xff16c9e6,
+            value: "There is no reason for any individual to have a computer in their home. -Ken Olsen, 1977",
+        },
+        StrToHash32 {
+            expected: 0xcc3d0ff2,
+            value: "It's a tiny change to the code and not completely disgusting. - Bob Manchek",
+        },
+        StrToHash32 {
+            expected: 0xd225e92e,
+            value: "The major problem is with sendmail.  -Mark Horton",
+        },
+        StrToHash32 {
+            expected: 0x1b8db5d0,
+            value: "Give me a rock, paper and scissors and I will move the world.  CCFestoon",
+        },
+        StrToHash32 {
+            expected: 0x4fda5f07,
+            value: "If the enemy is within range, then so are you.",
+        },
+        StrToHash32 {
+            expected: 0x2e18e880,
+            value: "It's well we cannot hear the screams/That we create in others' dreams.",
+        },
+        StrToHash32 {
+            expected: 0xd07de88f,
+            value: "You remind me of a TV show, but that's all right: I watch it anyway.",
+        },
+        StrToHash32 {
+            expected: 0x221694e4,
+            value: "C is as portable as Stonehedge!!",
+        },
+        StrToHash32 {
+            expected: 0xe2053c2c,
+            value: "Even if I could be Shakespeare, I think I should still choose to be Faraday. - A. Huxley",
+        },
+        StrToHash32 {
+            expected: 0x11c493bb,
+            value: "The fugacity of a constituent in a mixture of gases at a given temperature is proportional to its mole fraction.  Lewis-Randall Rule",
+        },
+        StrToHash32 {
+            expected: 0x0819a4e8,
+            value: "How can you write a big system without C++?  -Paul Glick",
+        },
     ];
     for s in str_to_hash32 {
         let hash = hash32((&s.value).as_bytes());

--- a/tests/test_hash64.rs
+++ b/tests/test_hash64.rs
@@ -5,30 +5,78 @@ use std::hash::Hasher;
 
 #[cfg(test)]
 struct StrToHash64<'a> {
-    value:    &'a str,
-    expected: u64
+    value: &'a str,
+    expected: u64,
 }
 
 #[test]
 fn test_hash64_0_to_16() {
     let str_to_hash64 = vec![
         // Hash32
-        StrToHash64{expected: 0x9ae16a3b2f90404f, value: ""},
-        StrToHash64{expected: 0xb3454265b6df75e3, value: "a"},
-        StrToHash64{expected: 0xaa8d6e5242ada51e, value: "ab"},
-        StrToHash64{expected: 0x24a5b3a074e7f369, value: "abc"},
-        StrToHash64{expected: 0x1a5502de4a1f8101, value: "abcd"},
-        StrToHash64{expected: 0xc22f4663e54e04d4, value: "abcde"},
-        StrToHash64{expected: 0xc329379e6a03c2cd, value: "abcdef"},
-        StrToHash64{expected: 0x3c40c92b1ccb7355, value: "abcdefg"},
-        StrToHash64{expected: 0xfee9d22990c82909, value: "abcdefgh"},
-        StrToHash64{expected: 0x332c8ed4dae5ba42, value: "abcdefghi"},
-        StrToHash64{expected: 0x8a3abb6a5f3fb7fb, value: "abcdefghij"},
-        StrToHash64{expected: 0x6a5d2fba44f012f8, value: "hi"},
-        StrToHash64{expected: 0x588fb7478bd6b01b, value: "hello world"},
-        StrToHash64{expected: 0x61bec68db00fa2ff, value: "lee@lmmrtech.com"},
-        StrToHash64{expected: 0x7fbbcd6191d8dce0, value: "fred@example.com"},
-        StrToHash64{expected: 0x80d73b843ba57db8, value: "size:  a.out:  bad magic"},
+        StrToHash64 {
+            expected: 0x9ae16a3b2f90404f,
+            value: "",
+        },
+        StrToHash64 {
+            expected: 0xb3454265b6df75e3,
+            value: "a",
+        },
+        StrToHash64 {
+            expected: 0xaa8d6e5242ada51e,
+            value: "ab",
+        },
+        StrToHash64 {
+            expected: 0x24a5b3a074e7f369,
+            value: "abc",
+        },
+        StrToHash64 {
+            expected: 0x1a5502de4a1f8101,
+            value: "abcd",
+        },
+        StrToHash64 {
+            expected: 0xc22f4663e54e04d4,
+            value: "abcde",
+        },
+        StrToHash64 {
+            expected: 0xc329379e6a03c2cd,
+            value: "abcdef",
+        },
+        StrToHash64 {
+            expected: 0x3c40c92b1ccb7355,
+            value: "abcdefg",
+        },
+        StrToHash64 {
+            expected: 0xfee9d22990c82909,
+            value: "abcdefgh",
+        },
+        StrToHash64 {
+            expected: 0x332c8ed4dae5ba42,
+            value: "abcdefghi",
+        },
+        StrToHash64 {
+            expected: 0x8a3abb6a5f3fb7fb,
+            value: "abcdefghij",
+        },
+        StrToHash64 {
+            expected: 0x6a5d2fba44f012f8,
+            value: "hi",
+        },
+        StrToHash64 {
+            expected: 0x588fb7478bd6b01b,
+            value: "hello world",
+        },
+        StrToHash64 {
+            expected: 0x61bec68db00fa2ff,
+            value: "lee@lmmrtech.com",
+        },
+        StrToHash64 {
+            expected: 0x7fbbcd6191d8dce0,
+            value: "fred@example.com",
+        },
+        StrToHash64 {
+            expected: 0x80d73b843ba57db8,
+            value: "size:  a.out:  bad magic",
+        },
     ];
     for s in str_to_hash64 {
         let hash = hash64((&s.value).as_bytes());
@@ -51,9 +99,18 @@ fn test_hash64_0_to_16() {
 fn test_hash64_17_to_32() {
     let str_to_hash64 = vec![
         // Hash32
-        StrToHash64{expected: 0xb678cf3842309f40, value: "docklandsman@gmail.com"},
-        StrToHash64{expected: 0x8eb3808d1ccfc779, value: "Nepal premier won't resign."},
-        StrToHash64{expected: 0xb944f8a16261e414, value: "C is as portable as Stonehedge!!"}
+        StrToHash64 {
+            expected: 0xb678cf3842309f40,
+            value: "docklandsman@gmail.com",
+        },
+        StrToHash64 {
+            expected: 0x8eb3808d1ccfc779,
+            value: "Nepal premier won't resign.",
+        },
+        StrToHash64 {
+            expected: 0xb944f8a16261e414,
+            value: "C is as portable as Stonehedge!!",
+        },
     ];
     for s in str_to_hash64 {
         let hash = hash64((&s.value).as_bytes());
@@ -73,15 +130,42 @@ fn test_hash64_17_to_32() {
 fn test_hash64_33_to_64() {
     let str_to_hash64 = vec![
         // Hash32
-        StrToHash64{expected: 0x2d072041b535155d, value: "Discard medicine more than two years old."}, //41
-        StrToHash64{expected: 0x9f9e3cdeb570f926, value: "He who has a shady past knows that nice guys finish last."},
-        StrToHash64{expected: 0x361b79df08615cd6, value: "I wouldn't marry him with a ten foot pole."},
-        StrToHash64{expected: 0xdcfb73d4de1111c6, value: "Free! Free!/A trip/to Mars/for 900/empty jars/Burma Shave"},
-        StrToHash64{expected: 0xd71bdfedb6182a5d, value: "The days of the digital watch are numbered.  -Tom Stoppard"},
-        StrToHash64{expected: 0x3df4b8e109629602, value: "His money is twice tainted: 'taint yours and 'taint mine."},
-        StrToHash64{expected: 0x1da6c1dfec23a597, value: "The major problem is with sendmail.  -Mark Horton"},
-        StrToHash64{expected: 0x1f232f3375914f0a, value: "If the enemy is within range, then so are you."},
-        StrToHash64{expected: 0xa29944470950e8e4, value: "How can you write a big system without C++?  -Paul Glick"}
+        StrToHash64 {
+            expected: 0x2d072041b535155d,
+            value: "Discard medicine more than two years old.",
+        }, //41
+        StrToHash64 {
+            expected: 0x9f9e3cdeb570f926,
+            value: "He who has a shady past knows that nice guys finish last.",
+        },
+        StrToHash64 {
+            expected: 0x361b79df08615cd6,
+            value: "I wouldn't marry him with a ten foot pole.",
+        },
+        StrToHash64 {
+            expected: 0xdcfb73d4de1111c6,
+            value: "Free! Free!/A trip/to Mars/for 900/empty jars/Burma Shave",
+        },
+        StrToHash64 {
+            expected: 0xd71bdfedb6182a5d,
+            value: "The days of the digital watch are numbered.  -Tom Stoppard",
+        },
+        StrToHash64 {
+            expected: 0x3df4b8e109629602,
+            value: "His money is twice tainted: 'taint yours and 'taint mine.",
+        },
+        StrToHash64 {
+            expected: 0x1da6c1dfec23a597,
+            value: "The major problem is with sendmail.  -Mark Horton",
+        },
+        StrToHash64 {
+            expected: 0x1f232f3375914f0a,
+            value: "If the enemy is within range, then so are you.",
+        },
+        StrToHash64 {
+            expected: 0xa29944470950e8e4,
+            value: "How can you write a big system without C++?  -Paul Glick",
+        },
     ];
     for s in str_to_hash64 {
         let hash = hash64((&s.value).as_bytes());
@@ -101,15 +185,42 @@ fn test_hash64_33_to_64() {
 fn test_hash64_else() {
     let str_to_hash64 = vec![
         // Hash32
-        StrToHash64{expected: 0x8452fbb0c8f98c4f, value: "For every action there is an equal and opposite government program."},
-        StrToHash64{expected: 0x7fee06e367562d44, value: "There is no reason for any individual to have a computer in their home. -Ken Olsen, 1977"},
-        StrToHash64{expected: 0x889b024bab17bf54, value: "It's a tiny change to the code and not completely disgusting. - Bob Manchek"},
-        StrToHash64{expected: 0xb8e2918a4398348d, value: "Give me a rock, paper and scissors and I will move the world.  CCFestoon"},
-        StrToHash64{expected: 0x796229f1faacec7e, value: "It's well we cannot hear the screams/That we create in others' dreams."},
-        StrToHash64{expected: 0x98d2fbd5131a5860, value: "You remind me of a TV show, but that's all right: I watch it anyway."},
-        StrToHash64{expected: 0x4c349a4ff7ac0c89, value: "Even if I could be Shakespeare, I think I should still choose to be Faraday. - A. Huxley"},
-        StrToHash64{expected: 0x98eff6958c5e91a,  value: "The fugacity of a constituent in a mixture of gases at a given temperature is proportional to its mole fraction.  Lewis-Randall Rule"},
-        StrToHash64{expected: 0x21609f6764c635ed, value: "Go is a tool for managing Go source code.Usage: go command [arguments]The commands are:    build       compile packages and dependencies    clean       remove object files    env         print Go environment information    fix         run go tool fix on packages    fmt         run gofmt on package sources    generate    generate Go files by processing source    get         download and install packages and dependencies    install     compile and install packages and dependencies    list        list packages    run         compile and run Go program    test        test packages    tool        run specified go tool    version     print Go version    vet         run go tool vet on packagesUse go help [command] for more information about a command.Additional help topics:    c           calling between Go and C    filetype    file types    gopath      GOPATH environment variable    importpath  import path syntax    packages    description of package lists    testflag    description of testing flags    testfunc    description of testing functionsUse go help [topic] for more information about that topic."},
+        StrToHash64 {
+            expected: 0x8452fbb0c8f98c4f,
+            value: "For every action there is an equal and opposite government program.",
+        },
+        StrToHash64 {
+            expected: 0x7fee06e367562d44,
+            value: "There is no reason for any individual to have a computer in their home. -Ken Olsen, 1977",
+        },
+        StrToHash64 {
+            expected: 0x889b024bab17bf54,
+            value: "It's a tiny change to the code and not completely disgusting. - Bob Manchek",
+        },
+        StrToHash64 {
+            expected: 0xb8e2918a4398348d,
+            value: "Give me a rock, paper and scissors and I will move the world.  CCFestoon",
+        },
+        StrToHash64 {
+            expected: 0x796229f1faacec7e,
+            value: "It's well we cannot hear the screams/That we create in others' dreams.",
+        },
+        StrToHash64 {
+            expected: 0x98d2fbd5131a5860,
+            value: "You remind me of a TV show, but that's all right: I watch it anyway.",
+        },
+        StrToHash64 {
+            expected: 0x4c349a4ff7ac0c89,
+            value: "Even if I could be Shakespeare, I think I should still choose to be Faraday. - A. Huxley",
+        },
+        StrToHash64 {
+            expected: 0x98eff6958c5e91a,
+            value: "The fugacity of a constituent in a mixture of gases at a given temperature is proportional to its mole fraction.  Lewis-Randall Rule",
+        },
+        StrToHash64 {
+            expected: 0x21609f6764c635ed,
+            value: "Go is a tool for managing Go source code.Usage: go command [arguments]The commands are:    build       compile packages and dependencies    clean       remove object files    env         print Go environment information    fix         run go tool fix on packages    fmt         run gofmt on package sources    generate    generate Go files by processing source    get         download and install packages and dependencies    install     compile and install packages and dependencies    list        list packages    run         compile and run Go program    test        test packages    tool        run specified go tool    version     print Go version    vet         run go tool vet on packagesUse go help [command] for more information about a command.Additional help topics:    c           calling between Go and C    filetype    file types    gopath      GOPATH environment variable    importpath  import path syntax    packages    description of package lists    testflag    description of testing flags    testfunc    description of testing functionsUse go help [topic] for more information about that topic.",
+        },
     ];
 
     for s in str_to_hash64 {


### PR DESCRIPTION
Changes:
- Add `rust-toolchain.toml` and pin the compiler to `1.91.1` for easier local development
- Set `edition = "2024"` in `Cargo.toml`
- Fix `cargo clippy` warnings
- Run `cargo fmt` to normalize formatting
- Update benchmarks to run on stable Rust (remove `#![feature(test)]`, switch to Criterion)
- Add `DefaultHasher` and `farmhash::fingerprint64` benchmarks alongside the existing SipHash and FarmHash benchmarks